### PR TITLE
Add app-shell, hero, page-header, auth, dashboard

### DIFF
--- a/packages/melodic-components/package.json
+++ b/packages/melodic-components/package.json
@@ -185,6 +185,30 @@
 			"types": "./lib/components/overlays/drawer/index.d.ts",
 			"default": "./lib/components/overlays/drawer/index.js"
 		},
+		"./app-shell": {
+			"types": "./lib/components/sections/app-shell/index.d.ts",
+			"default": "./lib/components/sections/app-shell/index.js"
+		},
+		"./hero-section": {
+			"types": "./lib/components/sections/hero/index.d.ts",
+			"default": "./lib/components/sections/hero/index.js"
+		},
+		"./page-header": {
+			"types": "./lib/components/sections/page-header/index.d.ts",
+			"default": "./lib/components/sections/page-header/index.js"
+		},
+		"./login-page": {
+			"types": "./lib/components/pages/auth/index.d.ts",
+			"default": "./lib/components/pages/auth/index.js"
+		},
+		"./signup-page": {
+			"types": "./lib/components/pages/auth/index.d.ts",
+			"default": "./lib/components/pages/auth/index.js"
+		},
+		"./dashboard-page": {
+			"types": "./lib/components/pages/dashboard/index.d.ts",
+			"default": "./lib/components/pages/dashboard/index.js"
+		},
 		"./directives": {
 			"types": "./lib/directives/index.d.ts",
 			"default": "./lib/directives/index.js"

--- a/packages/melodic-components/src/components/pages/auth/auth-layout.styles.ts
+++ b/packages/melodic-components/src/components/pages/auth/auth-layout.styles.ts
@@ -1,0 +1,173 @@
+export const authLayoutCss = `
+	/* ============================================
+	   AUTH LAYOUT - SHARED STYLES
+	   ============================================ */
+	:host {
+		display: block;
+		width: 100%;
+		height: 100%;
+	}
+
+	/* ============================================
+	   BASE WRAPPER
+	   ============================================ */
+	.ml-auth {
+		display: flex;
+		min-height: 100%;
+		height: 100%;
+		font-family: var(--ml-font-sans);
+		background-color: var(--ml-color-surface-secondary);
+	}
+
+	/* ============================================
+	   CENTERED VARIANT
+	   ============================================ */
+	.ml-auth--centered {
+		align-items: center;
+		justify-content: center;
+		padding: var(--ml-space-6);
+	}
+
+	.ml-auth--centered .ml-auth__card {
+		width: 100%;
+		max-width: 440px;
+		background-color: var(--ml-color-surface);
+		border: var(--ml-border) solid var(--ml-color-border);
+		border-radius: var(--ml-radius-xl);
+		box-shadow: var(--ml-shadow-lg);
+		padding: var(--ml-space-10);
+	}
+
+	/* ============================================
+	   SPLIT VARIANT
+	   ============================================ */
+	.ml-auth--split {
+		flex-direction: row;
+	}
+
+	.ml-auth--split .ml-auth__form-side {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex: 1;
+		padding: var(--ml-space-10);
+		background-color: var(--ml-color-surface);
+	}
+
+	.ml-auth--split .ml-auth__card {
+		width: 100%;
+		max-width: 440px;
+	}
+
+	.ml-auth--split .ml-auth__brand-side {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex: 1;
+		padding: var(--ml-space-10);
+		background-color: var(--ml-color-primary);
+		color: var(--ml-color-text-inverse);
+		position: relative;
+		overflow: hidden;
+	}
+
+	.ml-auth__brand-content {
+		position: relative;
+		z-index: 1;
+		text-align: center;
+		max-width: 480px;
+	}
+
+	.ml-auth__brand-content ::slotted(*) {
+		color: inherit;
+	}
+
+	/* ============================================
+	   LOGO AREA
+	   ============================================ */
+	.ml-auth__logo {
+		display: flex;
+		justify-content: center;
+		margin-bottom: var(--ml-space-6);
+	}
+
+	.ml-auth__logo:empty {
+		display: none;
+	}
+
+	/* ============================================
+	   HEADER
+	   ============================================ */
+	.ml-auth__header {
+		text-align: center;
+		margin-bottom: var(--ml-space-8);
+	}
+
+	.ml-auth__title {
+		margin: 0 0 var(--ml-space-2) 0;
+		font-size: var(--ml-text-2xl);
+		font-weight: var(--ml-font-bold);
+		color: var(--ml-color-text);
+		line-height: var(--ml-leading-tight);
+	}
+
+	.ml-auth__description {
+		margin: 0;
+		font-size: var(--ml-text-sm);
+		color: var(--ml-color-text-muted);
+		line-height: var(--ml-leading-normal);
+	}
+
+	/* ============================================
+	   FORM AREA
+	   ============================================ */
+	.ml-auth__form {
+		margin-bottom: var(--ml-space-6);
+	}
+
+	.ml-auth__form:empty {
+		display: none;
+	}
+
+	/* ============================================
+	   SOCIAL LOGIN
+	   ============================================ */
+	.ml-auth__social {
+		margin-bottom: var(--ml-space-6);
+	}
+
+	.ml-auth__social:empty {
+		display: none;
+	}
+
+	/* ============================================
+	   FOOTER
+	   ============================================ */
+	.ml-auth__footer {
+		text-align: center;
+		font-size: var(--ml-text-sm);
+		color: var(--ml-color-text-muted);
+	}
+
+	.ml-auth__footer:empty {
+		display: none;
+	}
+
+	/* ============================================
+	   RESPONSIVE - SPLIT COLLAPSE
+	   ============================================ */
+	@media (max-width: 768px) {
+		.ml-auth--split {
+			flex-direction: column;
+		}
+
+		.ml-auth--split .ml-auth__brand-side {
+			display: none;
+		}
+
+		.ml-auth--split .ml-auth__form-side {
+			min-height: 100%;
+			padding: var(--ml-space-6);
+		}
+	}
+`;

--- a/packages/melodic-components/src/components/pages/auth/index.ts
+++ b/packages/melodic-components/src/components/pages/auth/index.ts
@@ -1,0 +1,7 @@
+export { LoginPageComponent } from './login-page.component.js';
+export { loginPageTemplate } from './login-page.template.js';
+export { loginPageStyles } from './login-page.styles.js';
+
+export { SignupPageComponent } from './signup-page.component.js';
+export { signupPageTemplate } from './signup-page.template.js';
+export { signupPageStyles } from './signup-page.styles.js';

--- a/packages/melodic-components/src/components/pages/auth/login-page.component.ts
+++ b/packages/melodic-components/src/components/pages/auth/login-page.component.ts
@@ -1,0 +1,63 @@
+import { MelodicComponent } from '@melodicdev/core';
+import type { IElementRef } from '@melodicdev/core';
+import { loginPageTemplate } from './login-page.template.js';
+import { loginPageStyles } from './login-page.styles.js';
+
+/**
+ * ml-login-page - A full-page login component
+ *
+ * @example Centered:
+ * ```html
+ * <ml-login-page>
+ *   <div slot="logo"><img src="logo.svg" alt="Logo" /></div>
+ *   <form slot="form">...</form>
+ *   <div slot="footer">
+ *     <a href="/forgot">Forgot password?</a>
+ *     <a href="/signup">Sign up</a>
+ *   </div>
+ * </ml-login-page>
+ * ```
+ *
+ * @example Split variant:
+ * ```html
+ * <ml-login-page variant="split">
+ *   <form slot="form">...</form>
+ *   <div slot="brand">Welcome back to our platform</div>
+ * </ml-login-page>
+ * ```
+ *
+ * @slot logo - Brand logo area
+ * @slot header - Custom header content (overrides title/description props)
+ * @slot form - The login form
+ * @slot footer - Links like "Forgot password?", "Sign up"
+ * @slot social - Social login buttons
+ * @slot brand - Content for the brand side (split variant only)
+ */
+@MelodicComponent({
+	selector: 'ml-login-page',
+	template: loginPageTemplate,
+	styles: loginPageStyles,
+	attributes: ['variant', 'title', 'description']
+})
+export class LoginPageComponent implements IElementRef {
+	elementRef!: HTMLElement;
+
+	/** Layout variant */
+	variant: 'centered' | 'split' = 'centered';
+
+	/** Page title */
+	title = 'Log in to your account';
+
+	/** Page description */
+	description = 'Welcome back! Please enter your details.';
+
+	/** Check if header slot has content */
+	get hasHeaderSlot(): boolean {
+		return this.elementRef?.querySelector('[slot="header"]') !== null;
+	}
+
+	/** Check if brand slot has content */
+	get hasBrandSlot(): boolean {
+		return this.elementRef?.querySelector('[slot="brand"]') !== null;
+	}
+}

--- a/packages/melodic-components/src/components/pages/auth/login-page.styles.ts
+++ b/packages/melodic-components/src/components/pages/auth/login-page.styles.ts
@@ -1,0 +1,6 @@
+import { css } from '@melodicdev/core';
+import { authLayoutCss } from './auth-layout.styles.js';
+
+export const loginPageStyles = () => css`
+	${authLayoutCss}
+`;

--- a/packages/melodic-components/src/components/pages/auth/login-page.template.ts
+++ b/packages/melodic-components/src/components/pages/auth/login-page.template.ts
@@ -1,0 +1,68 @@
+import { html, classMap, when } from '@melodicdev/core';
+import type { LoginPageComponent } from './login-page.component.js';
+
+export function loginPageTemplate(c: LoginPageComponent) {
+	const isSplit = c.variant === 'split';
+
+	const cardContent = html`
+		<div class="ml-auth__logo">
+			<slot name="logo"></slot>
+		</div>
+
+		${when(
+			c.hasHeaderSlot,
+			() => html`
+				<div class="ml-auth__header">
+					<slot name="header"></slot>
+				</div>
+			`,
+			() => html`
+				<div class="ml-auth__header">
+					<h1 class="ml-auth__title">${c.title}</h1>
+					<p class="ml-auth__description">${c.description}</p>
+				</div>
+			`
+		)}
+
+		<div class="ml-auth__social">
+			<slot name="social"></slot>
+		</div>
+
+		<div class="ml-auth__form">
+			<slot name="form"></slot>
+		</div>
+
+		<div class="ml-auth__footer">
+			<slot name="footer"></slot>
+		</div>
+	`;
+
+	return html`
+		<div class=${classMap({
+			'ml-auth': true,
+			'ml-auth--centered': !isSplit,
+			'ml-auth--split': isSplit
+		})}>
+			${when(
+				isSplit,
+				() => html`
+					<div class="ml-auth__form-side">
+						<div class="ml-auth__card">
+							${cardContent}
+						</div>
+					</div>
+					<div class="ml-auth__brand-side">
+						<div class="ml-auth__brand-content">
+							<slot name="brand"></slot>
+						</div>
+					</div>
+				`,
+				() => html`
+					<div class="ml-auth__card">
+						${cardContent}
+					</div>
+				`
+			)}
+		</div>
+	`;
+}

--- a/packages/melodic-components/src/components/pages/auth/signup-page.component.ts
+++ b/packages/melodic-components/src/components/pages/auth/signup-page.component.ts
@@ -1,0 +1,62 @@
+import { MelodicComponent } from '@melodicdev/core';
+import type { IElementRef } from '@melodicdev/core';
+import { signupPageTemplate } from './signup-page.template.js';
+import { signupPageStyles } from './signup-page.styles.js';
+
+/**
+ * ml-signup-page - A full-page signup/registration component
+ *
+ * @example Centered:
+ * ```html
+ * <ml-signup-page>
+ *   <div slot="logo"><img src="logo.svg" alt="Logo" /></div>
+ *   <form slot="form">...</form>
+ *   <div slot="footer">
+ *     <a href="/login">Already have an account? Log in</a>
+ *   </div>
+ * </ml-signup-page>
+ * ```
+ *
+ * @example Split variant:
+ * ```html
+ * <ml-signup-page variant="split">
+ *   <form slot="form">...</form>
+ *   <div slot="brand">Join thousands of users</div>
+ * </ml-signup-page>
+ * ```
+ *
+ * @slot logo - Brand logo area
+ * @slot header - Custom header content (overrides title/description props)
+ * @slot form - The signup form
+ * @slot footer - Links like "Already have an account?"
+ * @slot social - Social signup buttons
+ * @slot brand - Content for the brand side (split variant only)
+ */
+@MelodicComponent({
+	selector: 'ml-signup-page',
+	template: signupPageTemplate,
+	styles: signupPageStyles,
+	attributes: ['variant', 'title', 'description']
+})
+export class SignupPageComponent implements IElementRef {
+	elementRef!: HTMLElement;
+
+	/** Layout variant */
+	variant: 'centered' | 'split' = 'centered';
+
+	/** Page title */
+	title = 'Create an account';
+
+	/** Page description */
+	description = 'Start your journey today.';
+
+	/** Check if header slot has content */
+	get hasHeaderSlot(): boolean {
+		return this.elementRef?.querySelector('[slot="header"]') !== null;
+	}
+
+	/** Check if brand slot has content */
+	get hasBrandSlot(): boolean {
+		return this.elementRef?.querySelector('[slot="brand"]') !== null;
+	}
+}

--- a/packages/melodic-components/src/components/pages/auth/signup-page.styles.ts
+++ b/packages/melodic-components/src/components/pages/auth/signup-page.styles.ts
@@ -1,0 +1,6 @@
+import { css } from '@melodicdev/core';
+import { authLayoutCss } from './auth-layout.styles.js';
+
+export const signupPageStyles = () => css`
+	${authLayoutCss}
+`;

--- a/packages/melodic-components/src/components/pages/auth/signup-page.template.ts
+++ b/packages/melodic-components/src/components/pages/auth/signup-page.template.ts
@@ -1,0 +1,68 @@
+import { html, classMap, when } from '@melodicdev/core';
+import type { SignupPageComponent } from './signup-page.component.js';
+
+export function signupPageTemplate(c: SignupPageComponent) {
+	const isSplit = c.variant === 'split';
+
+	const cardContent = html`
+		<div class="ml-auth__logo">
+			<slot name="logo"></slot>
+		</div>
+
+		${when(
+			c.hasHeaderSlot,
+			() => html`
+				<div class="ml-auth__header">
+					<slot name="header"></slot>
+				</div>
+			`,
+			() => html`
+				<div class="ml-auth__header">
+					<h1 class="ml-auth__title">${c.title}</h1>
+					<p class="ml-auth__description">${c.description}</p>
+				</div>
+			`
+		)}
+
+		<div class="ml-auth__social">
+			<slot name="social"></slot>
+		</div>
+
+		<div class="ml-auth__form">
+			<slot name="form"></slot>
+		</div>
+
+		<div class="ml-auth__footer">
+			<slot name="footer"></slot>
+		</div>
+	`;
+
+	return html`
+		<div class=${classMap({
+			'ml-auth': true,
+			'ml-auth--centered': !isSplit,
+			'ml-auth--split': isSplit
+		})}>
+			${when(
+				isSplit,
+				() => html`
+					<div class="ml-auth__form-side">
+						<div class="ml-auth__card">
+							${cardContent}
+						</div>
+					</div>
+					<div class="ml-auth__brand-side">
+						<div class="ml-auth__brand-content">
+							<slot name="brand"></slot>
+						</div>
+					</div>
+				`,
+				() => html`
+					<div class="ml-auth__card">
+						${cardContent}
+					</div>
+				`
+			)}
+		</div>
+	`;
+}

--- a/packages/melodic-components/src/components/pages/dashboard/dashboard-page.component.ts
+++ b/packages/melodic-components/src/components/pages/dashboard/dashboard-page.component.ts
@@ -1,0 +1,64 @@
+import { MelodicComponent } from '@melodicdev/core';
+import type { IElementRef } from '@melodicdev/core';
+import { dashboardPageTemplate } from './dashboard-page.template.js';
+import { dashboardPageStyles } from './dashboard-page.styles.js';
+
+export type DashboardLayout = 'default' | 'wide' | 'full';
+
+/**
+ * ml-dashboard-page - Composite dashboard layout component
+ *
+ * Composes ml-app-shell with ml-page-header to provide a complete
+ * dashboard page with sidebar, header, metrics row, main content,
+ * and optional aside column.
+ *
+ * @example
+ * ```html
+ * <ml-dashboard-page title="Dashboard" description="Overview of your account">
+ *   <ml-sidebar slot="sidebar">...</ml-sidebar>
+ *   <ml-button slot="header-actions" variant="primary">Create</ml-button>
+ *   <ml-stat slot="metrics">...</ml-stat>
+ *   <div slot="main">Main content</div>
+ *   <div slot="aside">Activity feed</div>
+ * </ml-dashboard-page>
+ * ```
+ *
+ * @slot sidebar - Sidebar content (passed through to app shell)
+ * @slot header-actions - Action buttons for the page header
+ * @slot metrics - Stat/metric cards row
+ * @slot main - Primary content area (tables, charts)
+ * @slot aside - Secondary content (activity feed, notifications)
+ */
+@MelodicComponent({
+	selector: 'ml-dashboard-page',
+	template: dashboardPageTemplate,
+	styles: dashboardPageStyles,
+	attributes: ['title', 'description', 'layout']
+})
+export class DashboardPageComponent implements IElementRef {
+	elementRef!: HTMLElement;
+
+	/** Page title */
+	title = '';
+
+	/** Page description */
+	description = '';
+
+	/** Content layout variant */
+	layout: DashboardLayout = 'default';
+
+	/** Check if metrics slot has content */
+	get hasMetrics(): boolean {
+		return this.elementRef?.querySelector('[slot="metrics"]') !== null;
+	}
+
+	/** Check if aside slot has content */
+	get hasAside(): boolean {
+		return this.elementRef?.querySelector('[slot="aside"]') !== null;
+	}
+
+	/** Check if header-actions slot has content */
+	get hasHeaderActions(): boolean {
+		return this.elementRef?.querySelector('[slot="header-actions"]') !== null;
+	}
+}

--- a/packages/melodic-components/src/components/pages/dashboard/dashboard-page.styles.ts
+++ b/packages/melodic-components/src/components/pages/dashboard/dashboard-page.styles.ts
@@ -1,0 +1,95 @@
+import { css } from '@melodicdev/core';
+
+export const dashboardPageStyles = () => css`
+	:host {
+		display: block;
+		height: 100%;
+	}
+
+	/* ============================================
+	   DASHBOARD CONTENT AREA
+	   ============================================ */
+	.ml-dashboard {
+		padding: var(--ml-space-6);
+		font-family: var(--ml-font-sans);
+	}
+
+	/* ============================================
+	   METRICS ROW
+	   ============================================ */
+	.ml-dashboard__metrics {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+		gap: var(--ml-space-4);
+		margin-bottom: var(--ml-space-6);
+	}
+
+	/* ============================================
+	   BODY (MAIN + ASIDE GRID)
+	   ============================================ */
+	.ml-dashboard__body {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: var(--ml-space-6);
+	}
+
+	/* Default layout: 2/3 main + 1/3 aside */
+	.ml-dashboard--default .ml-dashboard__body {
+		grid-template-columns: 2fr 1fr;
+	}
+
+	/* Wide layout: full-width main, aside below */
+	.ml-dashboard--wide .ml-dashboard__body {
+		grid-template-columns: 1fr;
+	}
+
+	/* Full layout: main only, no aside */
+	.ml-dashboard--full .ml-dashboard__body {
+		grid-template-columns: 1fr;
+	}
+
+	/* ============================================
+	   MAIN CONTENT
+	   ============================================ */
+	.ml-dashboard__main {
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--ml-space-6);
+	}
+
+	/* ============================================
+	   ASIDE
+	   ============================================ */
+	.ml-dashboard__aside {
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--ml-space-6);
+	}
+
+	/* ============================================
+	   RESPONSIVE
+	   ============================================ */
+	@media (max-width: 1024px) {
+		.ml-dashboard--default .ml-dashboard__body {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	@media (max-width: 640px) {
+		.ml-dashboard {
+			padding: var(--ml-space-4);
+		}
+
+		.ml-dashboard__metrics {
+			grid-template-columns: 1fr;
+			gap: var(--ml-space-3);
+			margin-bottom: var(--ml-space-4);
+		}
+
+		.ml-dashboard__body {
+			gap: var(--ml-space-4);
+		}
+	}
+`;

--- a/packages/melodic-components/src/components/pages/dashboard/dashboard-page.template.ts
+++ b/packages/melodic-components/src/components/pages/dashboard/dashboard-page.template.ts
@@ -1,0 +1,47 @@
+import { html, classMap, when } from '@melodicdev/core';
+import type { DashboardPageComponent } from './dashboard-page.component.js';
+
+export function dashboardPageTemplate(c: DashboardPageComponent) {
+	const showAside = c.layout === 'default' && c.hasAside;
+
+	return html`
+		<ml-app-shell>
+			<slot name="sidebar" slot="sidebar"></slot>
+
+			<ml-page-header
+				slot="header"
+				title=${c.title}
+				description=${c.description}
+			>
+				${when(c.hasHeaderActions, () => html`
+					<slot name="header-actions" slot="actions"></slot>
+				`)}
+			</ml-page-header>
+
+			<div
+				class=${classMap({
+					'ml-dashboard': true,
+					[`ml-dashboard--${c.layout}`]: true
+				})}
+			>
+				${when(c.hasMetrics, () => html`
+					<div class="ml-dashboard__metrics">
+						<slot name="metrics"></slot>
+					</div>
+				`)}
+
+				<div class="ml-dashboard__body">
+					<div class="ml-dashboard__main">
+						<slot name="main"></slot>
+					</div>
+
+					${when(showAside, () => html`
+						<div class="ml-dashboard__aside">
+							<slot name="aside"></slot>
+						</div>
+					`)}
+				</div>
+			</div>
+		</ml-app-shell>
+	`;
+}

--- a/packages/melodic-components/src/components/pages/dashboard/index.ts
+++ b/packages/melodic-components/src/components/pages/dashboard/index.ts
@@ -1,0 +1,5 @@
+export { DashboardPageComponent } from './dashboard-page.component.js';
+export { dashboardPageTemplate } from './dashboard-page.template.js';
+export { dashboardPageStyles } from './dashboard-page.styles.js';
+
+export type { DashboardLayout } from './dashboard-page.component.js';

--- a/packages/melodic-components/src/components/sections/app-shell/app-shell.component.ts
+++ b/packages/melodic-components/src/components/sections/app-shell/app-shell.component.ts
@@ -1,0 +1,85 @@
+import { MelodicComponent } from '@melodicdev/core';
+import type { IElementRef, OnCreate, OnDestroy } from '@melodicdev/core';
+import { appShellTemplate } from './app-shell.template.js';
+import { appShellStyles } from './app-shell.styles.js';
+
+export type SidebarPosition = 'left' | 'right';
+
+/**
+ * ml-app-shell - Application shell layout component
+ *
+ * Provides a sidebar + header + content area layout using CSS Grid.
+ *
+ * @example
+ * ```html
+ * <ml-app-shell>
+ *   <ml-sidebar slot="sidebar">...</ml-sidebar>
+ *   <div slot="header">Page Header</div>
+ *   <main>Content</main>
+ * </ml-app-shell>
+ * ```
+ *
+ * @slot sidebar - Sidebar navigation area (full height)
+ * @slot header - Top header bar in the main area
+ * @slot default - Main content area (scrolls independently)
+ */
+@MelodicComponent({
+	selector: 'ml-app-shell',
+	template: appShellTemplate,
+	styles: appShellStyles,
+	attributes: ['sidebar-position', 'sidebar-collapsed', 'header-fixed']
+})
+export class AppShellComponent implements IElementRef, OnCreate, OnDestroy {
+	elementRef!: HTMLElement;
+
+	/** Position of the sidebar: 'left' or 'right' */
+	'sidebar-position': SidebarPosition = 'left';
+
+	/** Whether the sidebar is collapsed */
+	'sidebar-collapsed' = false;
+
+	/** Whether the header is fixed/sticky */
+	'header-fixed' = false;
+
+	/** Internal: tracks if mobile drawer is open */
+	_mobileOpen = false;
+
+	/** Media query for responsive behavior */
+	private _mediaQuery: MediaQueryList | null = null;
+	private readonly _handleMediaChange = this.onMediaChange.bind(this);
+
+	get isMobile(): boolean {
+		return this._mediaQuery?.matches === false;
+	}
+
+	onCreate(): void {
+		this._mediaQuery = window.matchMedia('(min-width: 768px)');
+		this._mediaQuery.addEventListener('change', this._handleMediaChange);
+
+		// Close mobile drawer on initial desktop
+		if (!this.isMobile) {
+			this._mobileOpen = false;
+		}
+	}
+
+	onDestroy(): void {
+		this._mediaQuery?.removeEventListener('change', this._handleMediaChange);
+	}
+
+	/** Toggle mobile sidebar drawer */
+	toggleMobileSidebar = (): void => {
+		this._mobileOpen = !this._mobileOpen;
+	};
+
+	/** Close mobile sidebar */
+	closeMobileSidebar = (): void => {
+		this._mobileOpen = false;
+	};
+
+	private onMediaChange(event: MediaQueryListEvent): void {
+		if (event.matches) {
+			// Switched to desktop: close mobile drawer
+			this._mobileOpen = false;
+		}
+	}
+}

--- a/packages/melodic-components/src/components/sections/app-shell/app-shell.styles.ts
+++ b/packages/melodic-components/src/components/sections/app-shell/app-shell.styles.ts
@@ -1,0 +1,190 @@
+import { css } from '@melodicdev/core';
+
+export const appShellStyles = () => css`
+	:host {
+		display: block;
+		height: 100%;
+	}
+
+	/* ============================================
+	   SHELL GRID LAYOUT
+	   ============================================ */
+	.ml-app-shell {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		grid-template-rows: 1fr;
+		height: 100%;
+		overflow: hidden;
+	}
+
+	/* Sidebar on the right */
+	.ml-app-shell--sidebar-right {
+		grid-template-columns: 1fr auto;
+	}
+
+	.ml-app-shell--sidebar-right .ml-app-shell__sidebar {
+		order: 2;
+		border-left: var(--ml-border) solid var(--ml-color-border);
+		border-right: none;
+	}
+
+	.ml-app-shell--sidebar-right .ml-app-shell__main {
+		order: 1;
+	}
+
+	/* ============================================
+	   SIDEBAR
+	   ============================================ */
+	.ml-app-shell__sidebar {
+		grid-row: 1 / -1;
+		overflow: hidden;
+		border-right: var(--ml-border) solid var(--ml-color-border);
+	}
+
+	::slotted([slot="sidebar"]) {
+		height: 100%;
+	}
+
+	/* ============================================
+	   MAIN AREA
+	   ============================================ */
+	.ml-app-shell__main {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+		overflow: hidden;
+	}
+
+	/* ============================================
+	   HEADER
+	   ============================================ */
+	.ml-app-shell__header {
+		display: flex;
+		align-items: center;
+		flex-shrink: 0;
+		border-bottom: var(--ml-border) solid var(--ml-color-border);
+		background-color: var(--ml-color-surface);
+	}
+
+	.ml-app-shell__header:empty {
+		display: none;
+	}
+
+	/* Fixed/sticky header */
+	.ml-app-shell--header-fixed .ml-app-shell__header {
+		position: sticky;
+		top: 0;
+		z-index: 10;
+	}
+
+	/* ============================================
+	   CONTENT
+	   ============================================ */
+	.ml-app-shell__content {
+		flex: 1;
+		overflow-y: auto;
+		overflow-x: hidden;
+	}
+
+	/* Scrollbar styling */
+	.ml-app-shell__content::-webkit-scrollbar {
+		width: 6px;
+	}
+
+	.ml-app-shell__content::-webkit-scrollbar-track {
+		background: transparent;
+	}
+
+	.ml-app-shell__content::-webkit-scrollbar-thumb {
+		background-color: var(--ml-color-border);
+		border-radius: var(--ml-radius-full);
+	}
+
+	/* ============================================
+	   MOBILE MENU BUTTON
+	   ============================================ */
+	.ml-app-shell__menu-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+		width: 36px;
+		height: 36px;
+		margin-left: var(--ml-space-3);
+		padding: 0;
+		border: none;
+		border-radius: var(--ml-radius);
+		background: transparent;
+		color: var(--ml-color-text-secondary);
+		cursor: pointer;
+		transition: background-color var(--ml-duration-150) var(--ml-ease-in-out);
+	}
+
+	.ml-app-shell__menu-btn:hover {
+		background-color: var(--ml-color-surface-secondary);
+		color: var(--ml-color-text);
+	}
+
+	.ml-app-shell__menu-btn:focus-visible {
+		outline: 2px solid var(--ml-color-primary);
+		outline-offset: -2px;
+	}
+
+	/* ============================================
+	   MOBILE BACKDROP
+	   ============================================ */
+	.ml-app-shell__backdrop {
+		display: none;
+	}
+
+	/* ============================================
+	   RESPONSIVE: MOBILE (<768px)
+	   ============================================ */
+	@media (max-width: 767px) {
+		.ml-app-shell {
+			grid-template-columns: 1fr;
+		}
+
+		.ml-app-shell__sidebar {
+			position: fixed;
+			top: 0;
+			left: 0;
+			bottom: 0;
+			z-index: 50;
+			width: var(--ml-sidebar-width, 280px);
+			transform: translateX(-100%);
+			transition: transform var(--ml-duration-200) var(--ml-ease-in-out);
+			border-right: var(--ml-border) solid var(--ml-color-border);
+			background-color: var(--ml-color-surface);
+		}
+
+		.ml-app-shell--sidebar-right .ml-app-shell__sidebar {
+			left: auto;
+			right: 0;
+			transform: translateX(100%);
+			border-left: var(--ml-border) solid var(--ml-color-border);
+			border-right: none;
+		}
+
+		.ml-app-shell__sidebar--mobile-open {
+			transform: translateX(0);
+		}
+
+		/* Backdrop */
+		.ml-app-shell__backdrop {
+			display: block;
+			position: fixed;
+			inset: 0;
+			z-index: 40;
+			background-color: rgba(0, 0, 0, 0.4);
+			opacity: 0;
+			pointer-events: none;
+			transition: opacity var(--ml-duration-200) var(--ml-ease-in-out);
+		}
+
+		.ml-app-shell__backdrop--visible {
+			opacity: 1;
+			pointer-events: auto;
+		}
+	}
+`;

--- a/packages/melodic-components/src/components/sections/app-shell/app-shell.template.ts
+++ b/packages/melodic-components/src/components/sections/app-shell/app-shell.template.ts
@@ -1,0 +1,63 @@
+import { html, classMap, when } from '@melodicdev/core';
+import type { AppShellComponent } from './app-shell.component.js';
+
+export function appShellTemplate(c: AppShellComponent) {
+	const sidebarRight = c['sidebar-position'] === 'right';
+	const collapsed = c['sidebar-collapsed'];
+	const headerFixed = c['header-fixed'];
+	const mobileOpen = c._mobileOpen;
+	const isMobile = c.isMobile;
+
+	return html`
+		<div
+			class=${classMap({
+				'ml-app-shell': true,
+				'ml-app-shell--sidebar-right': sidebarRight,
+				'ml-app-shell--sidebar-collapsed': collapsed,
+				'ml-app-shell--header-fixed': headerFixed,
+				'ml-app-shell--mobile-open': mobileOpen
+			})}
+		>
+			${when(isMobile, () => html`
+				<div
+					class=${classMap({
+						'ml-app-shell__backdrop': true,
+						'ml-app-shell__backdrop--visible': mobileOpen
+					})}
+					@click=${c.closeMobileSidebar}
+				></div>
+			`)}
+
+			<aside
+				class=${classMap({
+					'ml-app-shell__sidebar': true,
+					'ml-app-shell__sidebar--mobile-open': mobileOpen
+				})}
+			>
+				<slot name="sidebar"></slot>
+			</aside>
+
+			<div class="ml-app-shell__main">
+				<header class="ml-app-shell__header">
+					${when(isMobile, () => html`
+						<button
+							class="ml-app-shell__menu-btn"
+							type="button"
+							aria-label="Toggle navigation"
+							@click=${c.toggleMobileSidebar}
+						>
+							<svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+								<path d="M3 5h14M3 10h14M3 15h14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+							</svg>
+						</button>
+					`)}
+					<slot name="header"></slot>
+				</header>
+
+				<div class="ml-app-shell__content">
+					<slot></slot>
+				</div>
+			</div>
+		</div>
+	`;
+}

--- a/packages/melodic-components/src/components/sections/app-shell/index.ts
+++ b/packages/melodic-components/src/components/sections/app-shell/index.ts
@@ -1,0 +1,5 @@
+export { AppShellComponent } from './app-shell.component.js';
+export { appShellTemplate } from './app-shell.template.js';
+export { appShellStyles } from './app-shell.styles.js';
+
+export type { SidebarPosition } from './app-shell.component.js';

--- a/packages/melodic-components/src/components/sections/hero/hero-section.component.ts
+++ b/packages/melodic-components/src/components/sections/hero/hero-section.component.ts
@@ -1,0 +1,55 @@
+import { MelodicComponent } from '@melodicdev/core';
+import type { IElementRef } from '@melodicdev/core';
+import { heroSectionTemplate } from './hero-section.template.js';
+import { heroSectionStyles } from './hero-section.styles.js';
+
+export type HeroVariant = 'centered' | 'split' | 'split-reverse';
+export type HeroSize = 'sm' | 'md' | 'lg';
+export type HeroBackground = 'none' | 'subtle' | 'gradient';
+
+/**
+ * ml-hero-section - Marketing hero/header section
+ *
+ * @example
+ * ```html
+ * <ml-hero-section variant="centered" size="lg">
+ *   <span slot="eyebrow">New Release</span>
+ *   <span slot="title">Build better apps</span>
+ *   <span slot="description">A modern framework for the modern web.</span>
+ *   <div slot="actions">
+ *     <ml-button variant="primary">Get Started</ml-button>
+ *   </div>
+ * </ml-hero-section>
+ * ```
+ *
+ * @slot eyebrow - Small text/badge above the title
+ * @slot title - Main headline (or use `title` property)
+ * @slot description - Supporting text (or use `description` property)
+ * @slot actions - CTA buttons
+ * @slot media - Image, video, or illustration
+ * @slot social-proof - Logos, testimonials, stats below CTA
+ */
+@MelodicComponent({
+	selector: 'ml-hero-section',
+	template: heroSectionTemplate,
+	styles: heroSectionStyles,
+	attributes: ['variant', 'size', 'background', 'title', 'description']
+})
+export class HeroSectionComponent implements IElementRef {
+	elementRef!: HTMLElement;
+
+	/** Layout variant */
+	variant: HeroVariant = 'centered';
+
+	/** Size controls padding and font sizes */
+	size: HeroSize = 'lg';
+
+	/** Background style */
+	background: HeroBackground = 'none';
+
+	/** Headline text (alternative to title slot) */
+	title = '';
+
+	/** Supporting text (alternative to description slot) */
+	description = '';
+}

--- a/packages/melodic-components/src/components/sections/hero/hero-section.styles.ts
+++ b/packages/melodic-components/src/components/sections/hero/hero-section.styles.ts
@@ -1,0 +1,267 @@
+import { css } from '@melodicdev/core';
+
+export const heroSectionStyles = () => css`
+	:host {
+		display: block;
+		width: 100%;
+	}
+
+	/* ============================================
+	   HERO CONTAINER
+	   ============================================ */
+	.ml-hero {
+		position: relative;
+		width: 100%;
+		font-family: var(--ml-font-sans);
+	}
+
+	/* ============================================
+	   SIZE VARIANTS (padding & font sizes)
+	   ============================================ */
+	.ml-hero--sm {
+		padding: var(--ml-space-12) var(--ml-space-6);
+	}
+
+	.ml-hero--md {
+		padding: var(--ml-space-20) var(--ml-space-6);
+	}
+
+	.ml-hero--lg {
+		padding: calc(var(--ml-space-20) + var(--ml-space-10)) var(--ml-space-6);
+	}
+
+	.ml-hero--sm .ml-hero__title,
+	.ml-hero--sm ::slotted([slot="title"]) {
+		font-size: var(--ml-text-3xl);
+		line-height: var(--ml-leading-tight);
+	}
+
+	.ml-hero--md .ml-hero__title,
+	.ml-hero--md ::slotted([slot="title"]) {
+		font-size: var(--ml-text-4xl);
+		line-height: var(--ml-leading-tight);
+	}
+
+	.ml-hero--lg .ml-hero__title,
+	.ml-hero--lg ::slotted([slot="title"]) {
+		font-size: var(--ml-text-5xl);
+		line-height: var(--ml-leading-tight);
+	}
+
+	.ml-hero--sm .ml-hero__description,
+	.ml-hero--sm ::slotted([slot="description"]) {
+		font-size: var(--ml-text-base);
+	}
+
+	.ml-hero--md .ml-hero__description,
+	.ml-hero--md ::slotted([slot="description"]) {
+		font-size: var(--ml-text-lg);
+	}
+
+	.ml-hero--lg .ml-hero__description,
+	.ml-hero--lg ::slotted([slot="description"]) {
+		font-size: var(--ml-text-xl);
+	}
+
+	/* ============================================
+	   BACKGROUND VARIANTS
+	   ============================================ */
+	.ml-hero--bg-subtle {
+		background-color: var(--ml-color-surface-secondary);
+	}
+
+	.ml-hero--bg-gradient {
+		background: linear-gradient(
+			135deg,
+			var(--ml-color-primary-subtle) 0%,
+			var(--ml-color-surface) 50%,
+			var(--ml-color-success-subtle, var(--ml-color-surface-secondary)) 100%
+		);
+	}
+
+	/* ============================================
+	   LAYOUT: CONTAINER
+	   ============================================ */
+	.ml-hero__container {
+		max-width: var(--ml-container-xl, 1280px);
+		margin: 0 auto;
+		width: 100%;
+	}
+
+	/* ============================================
+	   LAYOUT: CENTERED
+	   ============================================ */
+	.ml-hero--centered .ml-hero__container {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
+
+	.ml-hero--centered .ml-hero__content {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+		max-width: 800px;
+	}
+
+	.ml-hero--centered .ml-hero__media--below {
+		margin-top: var(--ml-space-10);
+		width: 100%;
+		display: flex;
+		justify-content: center;
+	}
+
+	/* ============================================
+	   LAYOUT: SPLIT
+	   ============================================ */
+	.ml-hero--split .ml-hero__container,
+	.ml-hero--split-reverse .ml-hero__container {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: var(--ml-space-12);
+		align-items: center;
+	}
+
+	.ml-hero--split-reverse .ml-hero__content {
+		order: 2;
+	}
+
+	.ml-hero--split-reverse .ml-hero__media {
+		order: 1;
+	}
+
+	.ml-hero--split .ml-hero__content,
+	.ml-hero--split-reverse .ml-hero__content {
+		display: flex;
+		flex-direction: column;
+	}
+
+	/* ============================================
+	   CONTENT ELEMENTS
+	   ============================================ */
+
+	/* Eyebrow */
+	::slotted([slot="eyebrow"]) {
+		display: inline-block;
+		margin-bottom: var(--ml-space-4);
+		font-size: var(--ml-text-sm);
+		font-weight: var(--ml-font-semibold);
+		color: var(--ml-color-primary);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	/* Title */
+	.ml-hero__title,
+	::slotted([slot="title"]) {
+		margin: 0 0 var(--ml-space-4) 0;
+		font-weight: var(--ml-font-bold);
+		color: var(--ml-color-text);
+		letter-spacing: -0.025em;
+	}
+
+	/* Description */
+	.ml-hero__description,
+	::slotted([slot="description"]) {
+		margin: 0 0 var(--ml-space-8) 0;
+		color: var(--ml-color-text-secondary);
+		line-height: var(--ml-leading-relaxed);
+		max-width: 640px;
+	}
+
+	/* Actions */
+	.ml-hero__actions {
+		display: flex;
+		gap: var(--ml-space-3);
+		flex-wrap: wrap;
+	}
+
+	.ml-hero--centered .ml-hero__actions {
+		justify-content: center;
+	}
+
+	.ml-hero__actions:empty {
+		display: none;
+	}
+
+	/* Media */
+	.ml-hero__media {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.ml-hero__media:empty {
+		display: none;
+	}
+
+	::slotted([slot="media"]) {
+		max-width: 100%;
+		height: auto;
+		border-radius: var(--ml-radius-lg);
+	}
+
+	/* Social proof */
+	.ml-hero__social-proof {
+		margin-top: var(--ml-space-10);
+		width: 100%;
+	}
+
+	.ml-hero--centered .ml-hero__social-proof {
+		text-align: center;
+	}
+
+	.ml-hero__social-proof:empty {
+		display: none;
+	}
+
+	/* ============================================
+	   RESPONSIVE: collapse split to stacked
+	   ============================================ */
+	@media (max-width: 768px) {
+		.ml-hero--split .ml-hero__container,
+		.ml-hero--split-reverse .ml-hero__container {
+			grid-template-columns: 1fr;
+		}
+
+		.ml-hero--split .ml-hero__content,
+		.ml-hero--split-reverse .ml-hero__content {
+			order: 1;
+			text-align: center;
+			align-items: center;
+		}
+
+		.ml-hero--split .ml-hero__media,
+		.ml-hero--split-reverse .ml-hero__media {
+			order: 2;
+		}
+
+		.ml-hero--split .ml-hero__actions,
+		.ml-hero--split-reverse .ml-hero__actions {
+			justify-content: center;
+		}
+
+		.ml-hero--lg {
+			padding: var(--ml-space-16) var(--ml-space-4);
+		}
+
+		.ml-hero--md {
+			padding: var(--ml-space-12) var(--ml-space-4);
+		}
+
+		.ml-hero--sm {
+			padding: var(--ml-space-8) var(--ml-space-4);
+		}
+
+		.ml-hero--lg .ml-hero__title,
+		.ml-hero--lg ::slotted([slot="title"]) {
+			font-size: var(--ml-text-3xl);
+		}
+
+		.ml-hero--md .ml-hero__title,
+		.ml-hero--md ::slotted([slot="title"]) {
+			font-size: var(--ml-text-2xl);
+		}
+	}
+`;

--- a/packages/melodic-components/src/components/sections/hero/hero-section.template.ts
+++ b/packages/melodic-components/src/components/sections/hero/hero-section.template.ts
@@ -1,0 +1,65 @@
+import { html, classMap, when } from '@melodicdev/core';
+import type { HeroSectionComponent } from './hero-section.component.js';
+
+export function heroSectionTemplate(c: HeroSectionComponent) {
+	const isSplit = c.variant === 'split' || c.variant === 'split-reverse';
+
+	return html`
+		<section
+			class=${classMap({
+				'ml-hero': true,
+				[`ml-hero--${c.variant}`]: true,
+				[`ml-hero--${c.size}`]: true,
+				[`ml-hero--bg-${c.background}`]: c.background !== 'none'
+			})}
+		>
+			<div class="ml-hero__container">
+				<div class="ml-hero__content">
+					<slot name="eyebrow">
+						${when(false, () => html``)}
+					</slot>
+
+					<slot name="title">
+						${when(!!c.title, () => html`
+							<h1 class="ml-hero__title">${c.title}</h1>
+						`)}
+					</slot>
+
+					<slot name="description">
+						${when(!!c.description, () => html`
+							<p class="ml-hero__description">${c.description}</p>
+						`)}
+					</slot>
+
+					<div class="ml-hero__actions">
+						<slot name="actions"></slot>
+					</div>
+
+					${when(!isSplit, () => html`
+						<div class="ml-hero__social-proof">
+							<slot name="social-proof"></slot>
+						</div>
+					`)}
+				</div>
+
+				${when(isSplit, () => html`
+					<div class="ml-hero__media">
+						<slot name="media"></slot>
+					</div>
+				`)}
+
+				${when(!isSplit, () => html`
+					<div class="ml-hero__media ml-hero__media--below">
+						<slot name="media"></slot>
+					</div>
+				`)}
+			</div>
+
+			${when(isSplit, () => html`
+				<div class="ml-hero__social-proof">
+					<slot name="social-proof"></slot>
+				</div>
+			`)}
+		</section>
+	`;
+}

--- a/packages/melodic-components/src/components/sections/hero/index.ts
+++ b/packages/melodic-components/src/components/sections/hero/index.ts
@@ -1,0 +1,5 @@
+export { HeroSectionComponent } from './hero-section.component.js';
+export { heroSectionTemplate } from './hero-section.template.js';
+export { heroSectionStyles } from './hero-section.styles.js';
+
+export type { HeroVariant, HeroSize, HeroBackground } from './hero-section.component.js';

--- a/packages/melodic-components/src/components/sections/page-header/index.ts
+++ b/packages/melodic-components/src/components/sections/page-header/index.ts
@@ -1,0 +1,5 @@
+export { PageHeaderComponent } from './page-header.component.js';
+export { pageHeaderTemplate } from './page-header.template.js';
+export { pageHeaderStyles } from './page-header.styles.js';
+
+export type { PageHeaderVariant } from './page-header.component.js';

--- a/packages/melodic-components/src/components/sections/page-header/page-header.component.ts
+++ b/packages/melodic-components/src/components/sections/page-header/page-header.component.ts
@@ -1,0 +1,79 @@
+import { MelodicComponent } from '@melodicdev/core';
+import type { IElementRef } from '@melodicdev/core';
+import { pageHeaderTemplate } from './page-header.template.js';
+import { pageHeaderStyles } from './page-header.styles.js';
+
+export type PageHeaderVariant = 'default' | 'compact' | 'centered';
+
+/**
+ * ml-page-header - Section component for page titles with breadcrumb, description, and actions
+ *
+ * @example
+ * ```html
+ * <ml-page-header title="Dashboard" description="Overview of your account">
+ *   <ml-breadcrumb slot="breadcrumb">
+ *     <ml-breadcrumb-item href="/">Home</ml-breadcrumb-item>
+ *     <ml-breadcrumb-item>Dashboard</ml-breadcrumb-item>
+ *   </ml-breadcrumb>
+ *   <ml-button slot="actions" variant="primary">Create New</ml-button>
+ * </ml-page-header>
+ * ```
+ *
+ * @slot breadcrumb - For ml-breadcrumb component
+ * @slot title - Page title (alternative to title property)
+ * @slot description - Supporting text below title
+ * @slot actions - Action buttons (right-aligned)
+ * @slot tabs - Optional tab navigation below the header
+ * @slot meta - Optional metadata area (badges, status, etc.)
+ */
+@MelodicComponent({
+	selector: 'ml-page-header',
+	template: pageHeaderTemplate,
+	styles: pageHeaderStyles,
+	attributes: ['variant', 'divider', 'title', 'description']
+})
+export class PageHeaderComponent implements IElementRef {
+	elementRef!: HTMLElement;
+
+	/** Page title text */
+	title = '';
+
+	/** Page description text */
+	description = '';
+
+	/** Visual variant */
+	variant: PageHeaderVariant = 'default';
+
+	/** Show bottom border */
+	divider = true;
+
+	/** Check if breadcrumb slot has content */
+	get hasBreadcrumb(): boolean {
+		return this.elementRef?.querySelector('[slot="breadcrumb"]') !== null;
+	}
+
+	/** Check if title slot has content */
+	get hasTitleSlot(): boolean {
+		return this.elementRef?.querySelector('[slot="title"]') !== null;
+	}
+
+	/** Check if description slot has content */
+	get hasDescriptionSlot(): boolean {
+		return this.elementRef?.querySelector('[slot="description"]') !== null;
+	}
+
+	/** Check if actions slot has content */
+	get hasActions(): boolean {
+		return this.elementRef?.querySelector('[slot="actions"]') !== null;
+	}
+
+	/** Check if tabs slot has content */
+	get hasTabs(): boolean {
+		return this.elementRef?.querySelector('[slot="tabs"]') !== null;
+	}
+
+	/** Check if meta slot has content */
+	get hasMeta(): boolean {
+		return this.elementRef?.querySelector('[slot="meta"]') !== null;
+	}
+}

--- a/packages/melodic-components/src/components/sections/page-header/page-header.styles.ts
+++ b/packages/melodic-components/src/components/sections/page-header/page-header.styles.ts
@@ -1,0 +1,167 @@
+import { css } from '@melodicdev/core';
+
+export const pageHeaderStyles = () => css`
+	:host {
+		display: block;
+	}
+
+	/* ============================================
+	   PAGE HEADER CONTAINER
+	   ============================================ */
+	.ml-page-header {
+		padding: var(--ml-space-6) var(--ml-space-6) var(--ml-space-4);
+		font-family: var(--ml-font-sans);
+	}
+
+	.ml-page-header--divider {
+		border-bottom: var(--ml-border) solid var(--ml-color-border);
+	}
+
+	/* ============================================
+	   COMPACT VARIANT
+	   ============================================ */
+	.ml-page-header--compact {
+		padding: var(--ml-space-4) var(--ml-space-6) var(--ml-space-3);
+	}
+
+	.ml-page-header--compact .ml-page-header__title h1 {
+		font-size: var(--ml-text-lg);
+	}
+
+	/* ============================================
+	   CENTERED VARIANT
+	   ============================================ */
+	.ml-page-header--centered {
+		text-align: center;
+	}
+
+	.ml-page-header--centered .ml-page-header__main {
+		flex-direction: column;
+		align-items: center;
+	}
+
+	.ml-page-header--centered .ml-page-header__content {
+		align-items: center;
+	}
+
+	.ml-page-header--centered .ml-page-header__actions {
+		margin-top: var(--ml-space-4);
+	}
+
+	.ml-page-header--centered .ml-page-header__breadcrumb {
+		justify-content: center;
+	}
+
+	/* ============================================
+	   BREADCRUMB
+	   ============================================ */
+	.ml-page-header__breadcrumb {
+		display: flex;
+		margin-bottom: var(--ml-space-3);
+	}
+
+	/* ============================================
+	   MAIN (title row + actions)
+	   ============================================ */
+	.ml-page-header__main {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: var(--ml-space-4);
+	}
+
+	/* ============================================
+	   CONTENT (title + description + meta)
+	   ============================================ */
+	.ml-page-header__content {
+		display: flex;
+		flex-direction: column;
+		gap: var(--ml-space-1);
+		min-width: 0;
+		flex: 1;
+	}
+
+	/* ============================================
+	   TITLE
+	   ============================================ */
+	.ml-page-header__title h1 {
+		margin: 0;
+		font-size: var(--ml-text-2xl);
+		font-weight: var(--ml-font-semibold);
+		line-height: var(--ml-leading-tight);
+		color: var(--ml-color-text);
+	}
+
+	.ml-page-header__title ::slotted(*) {
+		margin: 0;
+		font-size: var(--ml-text-2xl);
+		font-weight: var(--ml-font-semibold);
+		line-height: var(--ml-leading-tight);
+		color: var(--ml-color-text);
+	}
+
+	/* ============================================
+	   DESCRIPTION
+	   ============================================ */
+	.ml-page-header__description p {
+		margin: 0;
+		font-size: var(--ml-text-sm);
+		line-height: var(--ml-leading-normal);
+		color: var(--ml-color-text-secondary);
+	}
+
+	.ml-page-header__description ::slotted(*) {
+		margin: 0;
+		font-size: var(--ml-text-sm);
+		line-height: var(--ml-leading-normal);
+		color: var(--ml-color-text-secondary);
+	}
+
+	/* ============================================
+	   META
+	   ============================================ */
+	.ml-page-header__meta {
+		display: flex;
+		align-items: center;
+		gap: var(--ml-space-2);
+		margin-top: var(--ml-space-2);
+	}
+
+	/* ============================================
+	   ACTIONS
+	   ============================================ */
+	.ml-page-header__actions {
+		display: flex;
+		align-items: center;
+		gap: var(--ml-space-2);
+		flex-shrink: 0;
+	}
+
+	/* ============================================
+	   TABS
+	   ============================================ */
+	.ml-page-header__tabs {
+		margin-top: var(--ml-space-4);
+	}
+
+	/* ============================================
+	   RESPONSIVE
+	   ============================================ */
+	@media (max-width: 640px) {
+		.ml-page-header {
+			padding: var(--ml-space-4);
+		}
+
+		.ml-page-header__main {
+			flex-direction: column;
+		}
+
+		.ml-page-header__actions {
+			width: 100%;
+		}
+
+		.ml-page-header__actions ::slotted(*) {
+			flex: 1;
+		}
+	}
+`;

--- a/packages/melodic-components/src/components/sections/page-header/page-header.template.ts
+++ b/packages/melodic-components/src/components/sections/page-header/page-header.template.ts
@@ -1,0 +1,63 @@
+import { html, classMap, when } from '@melodicdev/core';
+import type { PageHeaderComponent } from './page-header.component.js';
+
+export function pageHeaderTemplate(c: PageHeaderComponent) {
+	const hasTitle = !!(c.title || c.hasTitleSlot);
+	const hasDescription = !!(c.description || c.hasDescriptionSlot);
+
+	return html`
+		<header
+			class=${classMap({
+				'ml-page-header': true,
+				[`ml-page-header--${c.variant}`]: true,
+				'ml-page-header--divider': c.divider
+			})}
+		>
+			${when(c.hasBreadcrumb, () => html`
+				<div class="ml-page-header__breadcrumb">
+					<slot name="breadcrumb"></slot>
+				</div>
+			`)}
+
+			<div class="ml-page-header__main">
+				<div class="ml-page-header__content">
+					${when(hasTitle, () => html`
+						<div class="ml-page-header__title">
+							${when(c.hasTitleSlot,
+								() => html`<slot name="title"></slot>`,
+								() => html`<h1>${c.title}</h1>`
+							)}
+						</div>
+					`)}
+
+					${when(hasDescription, () => html`
+						<div class="ml-page-header__description">
+							${when(c.hasDescriptionSlot,
+								() => html`<slot name="description"></slot>`,
+								() => html`<p>${c.description}</p>`
+							)}
+						</div>
+					`)}
+
+					${when(c.hasMeta, () => html`
+						<div class="ml-page-header__meta">
+							<slot name="meta"></slot>
+						</div>
+					`)}
+				</div>
+
+				${when(c.hasActions, () => html`
+					<div class="ml-page-header__actions">
+						<slot name="actions"></slot>
+					</div>
+				`)}
+			</div>
+
+			${when(c.hasTabs, () => html`
+				<div class="ml-page-header__tabs">
+					<slot name="tabs"></slot>
+				</div>
+			`)}
+		</header>
+	`;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -56,6 +56,12 @@
 			"@melodicdev/components/slider": ["packages/melodic-components/src/components/forms/slider/index.ts"],
 			"@melodicdev/components/button-group": ["packages/melodic-components/src/components/forms/button-group/index.ts"],
 			"@melodicdev/components/drawer": ["packages/melodic-components/src/components/overlays/drawer/index.ts"],
+			"@melodicdev/components/app-shell": ["packages/melodic-components/src/components/sections/app-shell/index.ts"],
+			"@melodicdev/components/hero-section": ["packages/melodic-components/src/components/sections/hero/index.ts"],
+			"@melodicdev/components/page-header": ["packages/melodic-components/src/components/sections/page-header/index.ts"],
+			"@melodicdev/components/login-page": ["packages/melodic-components/src/components/pages/auth/index.ts"],
+			"@melodicdev/components/signup-page": ["packages/melodic-components/src/components/pages/auth/index.ts"],
+			"@melodicdev/components/dashboard-page": ["packages/melodic-components/src/components/pages/dashboard/index.ts"],
 			"@melodicdev/components/directives": ["packages/melodic-components/src/directives/index.ts"]
 		},
 

--- a/vite.config.demo.ts
+++ b/vite.config.demo.ts
@@ -59,6 +59,12 @@ export default defineConfig({
 			'@melodicdev/components/slider': resolve(__dirname, 'packages/melodic-components/src/components/forms/slider/index.ts'),
 			'@melodicdev/components/button-group': resolve(__dirname, 'packages/melodic-components/src/components/forms/button-group/index.ts'),
 			'@melodicdev/components/drawer': resolve(__dirname, 'packages/melodic-components/src/components/overlays/drawer/index.ts'),
+			'@melodicdev/components/app-shell': resolve(__dirname, 'packages/melodic-components/src/components/sections/app-shell/index.ts'),
+			'@melodicdev/components/hero-section': resolve(__dirname, 'packages/melodic-components/src/components/sections/hero/index.ts'),
+			'@melodicdev/components/page-header': resolve(__dirname, 'packages/melodic-components/src/components/sections/page-header/index.ts'),
+			'@melodicdev/components/login-page': resolve(__dirname, 'packages/melodic-components/src/components/pages/auth/index.ts'),
+			'@melodicdev/components/signup-page': resolve(__dirname, 'packages/melodic-components/src/components/pages/auth/index.ts'),
+			'@melodicdev/components/dashboard-page': resolve(__dirname, 'packages/melodic-components/src/components/pages/dashboard/index.ts'),
 			'@melodicdev/components/directives': resolve(__dirname, 'packages/melodic-components/src/directives/index.ts'),
 			'@melodicdev/components': resolve(__dirname, 'packages/melodic-components/src/index.ts')
 		}

--- a/web/demo/components/demo-app/demo-app.template.ts
+++ b/web/demo/components/demo-app/demo-app.template.ts
@@ -139,6 +139,28 @@ export const demoAppTemplate = (c: DemoApp) => {
 					<a href="#drawers" class="demo-nav__item" @click=${(event: Event) => c.handleNavClick(event, 'drawers')}>
 						<ml-icon icon="sidebar" size="sm"></ml-icon>Drawers
 					</a>
+
+					<span class="demo-nav__label">Sections</span>
+					<a href="#app-shell" class="demo-nav__item" @click=${(event: Event) => c.handleNavClick(event, 'app-shell')}>
+						<ml-icon icon="layout" size="sm"></ml-icon>App Shell
+					</a>
+					<a href="#page-header" class="demo-nav__item" @click=${(event: Event) => c.handleNavClick(event, 'page-header')}>
+						<ml-icon icon="article" size="sm"></ml-icon>Page Header
+					</a>
+					<a href="#hero-section" class="demo-nav__item" @click=${(event: Event) => c.handleNavClick(event, 'hero-section')}>
+						<ml-icon icon="star" size="sm"></ml-icon>Hero Section
+					</a>
+
+					<span class="demo-nav__label">Pages</span>
+					<a href="#login-page" class="demo-nav__item" @click=${(event: Event) => c.handleNavClick(event, 'login-page')}>
+						<ml-icon icon="sign-in" size="sm"></ml-icon>Login Page
+					</a>
+					<a href="#signup-page" class="demo-nav__item" @click=${(event: Event) => c.handleNavClick(event, 'signup-page')}>
+						<ml-icon icon="user-plus" size="sm"></ml-icon>Signup Page
+					</a>
+					<a href="#dashboard-page" class="demo-nav__item" @click=${(event: Event) => c.handleNavClick(event, 'dashboard-page')}>
+						<ml-icon icon="chart-bar" size="sm"></ml-icon>Dashboard Page
+					</a>
 				</nav>
 
 				<div class="demo-sidebar__footer">
@@ -2505,6 +2527,399 @@ const routes = [
 									<h3 slot="drawer-header">Large Drawer</h3>
 									<p>640px wide panel.</p>
 								</ml-drawer>
+							</div>
+						</div>
+					</section>
+
+					<!-- ============================================
+					     SECTIONS
+					     ============================================ -->
+
+					<!-- App Shell Section -->
+					<section id="app-shell" class="demo-section">
+						<div class="demo-section__header">
+							<h2>App Shell</h2>
+							<p>Application layout component with sidebar, header, and content areas using CSS Grid.</p>
+						</div>
+
+						<div class="demo-card">
+							<div class="demo-card__header">
+								<h3>Default Layout</h3>
+								<span class="demo-card__badge">Sidebar + Content</span>
+							</div>
+							<div style="height: 400px; border: var(--ml-border) solid var(--ml-color-border); border-radius: var(--ml-radius-lg); overflow: hidden;">
+								<ml-app-shell>
+									<div slot="sidebar" style="padding: var(--ml-space-4); background: var(--ml-color-surface); border-right: var(--ml-border) solid var(--ml-color-border); height: 100%; box-sizing: border-box; font-family: var(--ml-font-sans);">
+										<div style="font-weight: var(--ml-font-semibold); font-size: var(--ml-text-sm); margin-bottom: var(--ml-space-4);">Sidebar</div>
+										<div style="display: flex; flex-direction: column; gap: var(--ml-space-2);">
+											<span style="font-size: var(--ml-text-sm); color: var(--ml-color-text-secondary);">Nav Item 1</span>
+											<span style="font-size: var(--ml-text-sm); color: var(--ml-color-text-secondary);">Nav Item 2</span>
+											<span style="font-size: var(--ml-text-sm); color: var(--ml-color-text-secondary);">Nav Item 3</span>
+										</div>
+									</div>
+									<div slot="header" style="font-family: var(--ml-font-sans); font-weight: var(--ml-font-semibold); font-size: var(--ml-text-lg); color: var(--ml-color-text);">
+										Page Title
+									</div>
+									<div style="padding: var(--ml-space-6); font-family: var(--ml-font-sans);">
+										<p style="color: var(--ml-color-text-secondary); font-size: var(--ml-text-sm);">Main content area. This scrolls independently from the sidebar and header.</p>
+									</div>
+								</ml-app-shell>
+							</div>
+						</div>
+
+						<div class="demo-card">
+							<div class="demo-card__header">
+								<h3>Fixed Header</h3>
+								<span class="demo-card__badge">header-fixed</span>
+							</div>
+							<div style="height: 300px; border: var(--ml-border) solid var(--ml-color-border); border-radius: var(--ml-radius-lg); overflow: hidden;">
+								<ml-app-shell header-fixed>
+									<div slot="sidebar" style="padding: var(--ml-space-4); background: var(--ml-color-surface); border-right: var(--ml-border) solid var(--ml-color-border); height: 100%; box-sizing: border-box; font-family: var(--ml-font-sans);">
+										<div style="font-weight: var(--ml-font-semibold); font-size: var(--ml-text-sm);">Sidebar</div>
+									</div>
+									<div slot="header" style="font-family: var(--ml-font-sans); font-weight: var(--ml-font-semibold); font-size: var(--ml-text-sm); color: var(--ml-color-text);">
+										Fixed Header
+									</div>
+									<div style="padding: var(--ml-space-6); font-family: var(--ml-font-sans); font-size: var(--ml-text-sm); color: var(--ml-color-text-secondary);">
+										<p>The header stays fixed while content scrolls.</p>
+									</div>
+								</ml-app-shell>
+							</div>
+						</div>
+					</section>
+
+					<!-- Page Header Section -->
+					<section id="page-header" class="demo-section">
+						<div class="demo-section__header">
+							<h2>Page Header</h2>
+							<p>Section component for page titles with breadcrumb, description, and action buttons.</p>
+						</div>
+
+						<div class="demo-card">
+							<div class="demo-card__header">
+								<h3>Default</h3>
+								<span class="demo-card__badge">Title + Actions</span>
+							</div>
+							<div style="border: var(--ml-border) solid var(--ml-color-border); border-radius: var(--ml-radius-lg); overflow: hidden;">
+								<ml-page-header title="Team Members" description="Manage your team members and their account permissions here.">
+									<ml-breadcrumb slot="breadcrumb">
+										<ml-breadcrumb-item href="#">Home</ml-breadcrumb-item>
+										<ml-breadcrumb-item href="#">Settings</ml-breadcrumb-item>
+										<ml-breadcrumb-item>Team</ml-breadcrumb-item>
+									</ml-breadcrumb>
+									<ml-button slot="actions" variant="outline" size="sm">
+										<ml-icon icon="download-simple" size="sm"></ml-icon>Export
+									</ml-button>
+									<ml-button slot="actions" variant="primary" size="sm">
+										<ml-icon icon="plus" size="sm"></ml-icon>Add Member
+									</ml-button>
+								</ml-page-header>
+							</div>
+						</div>
+
+						<div class="demo-card">
+							<div class="demo-card__header">
+								<h3>Compact Variant</h3>
+								<span class="demo-card__badge">Less padding</span>
+							</div>
+							<div style="border: var(--ml-border) solid var(--ml-color-border); border-radius: var(--ml-radius-lg); overflow: hidden;">
+								<ml-page-header variant="compact" title="Settings" description="Manage your account settings.">
+									<ml-button slot="actions" variant="outline" size="sm">Cancel</ml-button>
+									<ml-button slot="actions" variant="primary" size="sm">Save Changes</ml-button>
+								</ml-page-header>
+							</div>
+						</div>
+
+						<div class="demo-card">
+							<div class="demo-card__header">
+								<h3>Centered Variant</h3>
+								<span class="demo-card__badge">Centered layout</span>
+							</div>
+							<div style="border: var(--ml-border) solid var(--ml-color-border); border-radius: var(--ml-radius-lg); overflow: hidden;">
+								<ml-page-header variant="centered" title="Welcome to Your Dashboard" description="Here you can manage all of your projects, team members, and settings.">
+									<ml-button slot="actions" variant="primary">Get Started</ml-button>
+								</ml-page-header>
+							</div>
+						</div>
+
+						<div class="demo-card">
+							<div class="demo-card__header">
+								<h3>With Meta</h3>
+								<span class="demo-card__badge">Badges + status</span>
+							</div>
+							<div style="border: var(--ml-border) solid var(--ml-color-border); border-radius: var(--ml-radius-lg); overflow: hidden;">
+								<ml-page-header title="Project Alpha" description="Mobile app redesign for Q1 2026">
+									<ml-badge slot="meta" variant="success" size="sm">Active</ml-badge>
+									<ml-badge slot="meta" variant="default" size="sm">v2.1.0</ml-badge>
+									<ml-button slot="actions" variant="outline" size="sm">
+										<ml-icon icon="gear" size="sm"></ml-icon>Settings
+									</ml-button>
+								</ml-page-header>
+							</div>
+						</div>
+
+						<div class="demo-card">
+							<div class="demo-card__header">
+								<h3>No Divider</h3>
+							</div>
+							<div style="border: var(--ml-border) solid var(--ml-color-border); border-radius: var(--ml-radius-lg); overflow: hidden; background: var(--ml-color-surface-secondary);">
+								<ml-page-header title="Notifications" divider="false"></ml-page-header>
+							</div>
+						</div>
+					</section>
+
+					<!-- Hero Section -->
+					<section id="hero-section" class="demo-section">
+						<div class="demo-section__header">
+							<h2>Hero Section</h2>
+							<p>Marketing hero/header section with support for centered and split layouts.</p>
+						</div>
+
+						<div class="demo-card">
+							<div class="demo-card__header">
+								<h3>Centered</h3>
+								<span class="demo-card__badge">Default</span>
+							</div>
+							<div style="border: var(--ml-border) solid var(--ml-color-border); border-radius: var(--ml-radius-lg); overflow: hidden;">
+								<ml-hero-section variant="centered" size="md" background="subtle">
+									<ml-badge slot="eyebrow" variant="primary" size="sm" pill>New Release</ml-badge>
+									<span slot="title">Build amazing web apps with Melodic</span>
+									<span slot="description">A modern, lightweight web component framework with built-in routing, state management, and a beautiful component library.</span>
+									<div slot="actions" style="display: flex; gap: var(--ml-space-3); justify-content: center;">
+										<ml-button variant="primary" size="lg">Get Started</ml-button>
+										<ml-button variant="outline" size="lg">Documentation</ml-button>
+									</div>
+								</ml-hero-section>
+							</div>
+						</div>
+
+						<div class="demo-card">
+							<div class="demo-card__header">
+								<h3>Split Layout</h3>
+								<span class="demo-card__badge">Content + Media</span>
+							</div>
+							<div style="border: var(--ml-border) solid var(--ml-color-border); border-radius: var(--ml-radius-lg); overflow: hidden;">
+								<ml-hero-section variant="split" size="sm">
+									<span slot="title">Ship features faster</span>
+									<span slot="description">Melodic gives you everything you need to build production-ready web applications in record time.</span>
+									<div slot="actions" style="display: flex; gap: var(--ml-space-3);">
+										<ml-button variant="primary">Start Free Trial</ml-button>
+										<ml-button variant="ghost">Learn More</ml-button>
+									</div>
+									<div slot="media" style="background: var(--ml-color-surface-secondary); border-radius: var(--ml-radius-lg); height: 280px; display: flex; align-items: center; justify-content: center; color: var(--ml-color-text-muted); font-family: var(--ml-font-sans); font-size: var(--ml-text-sm);">
+										Image / Illustration
+									</div>
+								</ml-hero-section>
+							</div>
+						</div>
+
+						<div class="demo-card">
+							<div class="demo-card__header">
+								<h3>Gradient Background</h3>
+								<span class="demo-card__badge">background="gradient"</span>
+							</div>
+							<div style="border: var(--ml-border) solid var(--ml-color-border); border-radius: var(--ml-radius-lg); overflow: hidden;">
+								<ml-hero-section variant="centered" size="sm" background="gradient">
+									<span slot="title">Start your journey today</span>
+									<span slot="description">Join thousands of developers building with Melodic.</span>
+									<div slot="actions" style="display: flex; gap: var(--ml-space-3); justify-content: center;">
+										<ml-button variant="primary">Sign Up Free</ml-button>
+									</div>
+								</ml-hero-section>
+							</div>
+						</div>
+					</section>
+
+					<!-- ============================================
+					     PAGES
+					     ============================================ -->
+
+					<!-- Login Page Section -->
+					<section id="login-page" class="demo-section">
+						<div class="demo-section__header">
+							<h2>Login Page</h2>
+							<p>Full-page login component with centered and split layout variants.</p>
+						</div>
+
+						<div class="demo-card">
+							<div class="demo-card__header">
+								<h3>Centered (Default)</h3>
+								<span class="demo-card__badge">Card layout</span>
+							</div>
+							<div style="border: var(--ml-border) solid var(--ml-color-border); border-radius: var(--ml-radius-lg); overflow: hidden;">
+								<ml-login-page>
+									<div slot="logo" style="display: flex; align-items: center; gap: var(--ml-space-2); justify-content: center;">
+										<div style="width: 32px; height: 32px; border-radius: var(--ml-radius); background: var(--ml-color-primary); display: flex; align-items: center; justify-content: center; color: white; font-weight: var(--ml-font-bold); font-size: var(--ml-text-sm);">M</div>
+									</div>
+									<div slot="social" style="display: flex; flex-direction: column; gap: var(--ml-space-2); font-family: var(--ml-font-sans);">
+										<ml-button variant="outline" full-width>
+											<ml-icon icon="google-logo" size="sm"></ml-icon>Sign in with Google
+										</ml-button>
+									</div>
+									<div slot="form" style="display: flex; flex-direction: column; gap: var(--ml-space-4); font-family: var(--ml-font-sans);">
+										<ml-form-field label="Email">
+											<ml-input type="email" placeholder="Enter your email"></ml-input>
+										</ml-form-field>
+										<ml-form-field label="Password">
+											<ml-input type="password" placeholder="Enter your password"></ml-input>
+										</ml-form-field>
+										<ml-button variant="primary" full-width>Sign In</ml-button>
+									</div>
+									<div slot="footer" style="text-align: center; font-family: var(--ml-font-sans); font-size: var(--ml-text-sm); color: var(--ml-color-text-secondary);">
+										Don't have an account? <a href="#" style="color: var(--ml-color-primary); text-decoration: none; font-weight: var(--ml-font-medium);">Sign up</a>
+									</div>
+								</ml-login-page>
+							</div>
+						</div>
+
+						<div class="demo-card">
+							<div class="demo-card__header">
+								<h3>Split Variant</h3>
+								<span class="demo-card__badge">Form + Brand</span>
+							</div>
+							<div style="min-height: 500px; border: var(--ml-border) solid var(--ml-color-border); border-radius: var(--ml-radius-lg); overflow: hidden;">
+								<ml-login-page variant="split">
+									<div slot="form" style="display: flex; flex-direction: column; gap: var(--ml-space-4); font-family: var(--ml-font-sans);">
+										<ml-form-field label="Email">
+											<ml-input type="email" placeholder="Enter your email"></ml-input>
+										</ml-form-field>
+										<ml-form-field label="Password">
+											<ml-input type="password" placeholder="Enter your password"></ml-input>
+										</ml-form-field>
+										<ml-button variant="primary" full-width>Sign In</ml-button>
+									</div>
+									<div slot="brand" style="display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; font-family: var(--ml-font-sans); color: white; text-align: center; padding: var(--ml-space-8);">
+										<h2 style="font-size: var(--ml-text-2xl); font-weight: var(--ml-font-bold); margin: 0 0 var(--ml-space-2) 0;">Welcome Back</h2>
+										<p style="font-size: var(--ml-text-base); opacity: 0.9; margin: 0;">Sign in to continue to your dashboard.</p>
+									</div>
+								</ml-login-page>
+							</div>
+						</div>
+					</section>
+
+					<!-- Signup Page Section -->
+					<section id="signup-page" class="demo-section">
+						<div class="demo-section__header">
+							<h2>Signup Page</h2>
+							<p>Full-page registration component with centered and split layout variants.</p>
+						</div>
+
+						<div class="demo-card">
+							<div class="demo-card__header">
+								<h3>Centered (Default)</h3>
+								<span class="demo-card__badge">Card layout</span>
+							</div>
+							<div style="border: var(--ml-border) solid var(--ml-color-border); border-radius: var(--ml-radius-lg); overflow: hidden;">
+								<ml-signup-page>
+									<div slot="logo" style="display: flex; align-items: center; gap: var(--ml-space-2); justify-content: center;">
+										<div style="width: 32px; height: 32px; border-radius: var(--ml-radius); background: var(--ml-color-primary); display: flex; align-items: center; justify-content: center; color: white; font-weight: var(--ml-font-bold); font-size: var(--ml-text-sm);">M</div>
+									</div>
+									<div slot="social" style="display: flex; flex-direction: column; gap: var(--ml-space-2); font-family: var(--ml-font-sans);">
+										<ml-button variant="outline" full-width>
+											<ml-icon icon="google-logo" size="sm"></ml-icon>Sign up with Google
+										</ml-button>
+									</div>
+									<div slot="form" style="display: flex; flex-direction: column; gap: var(--ml-space-4); font-family: var(--ml-font-sans);">
+										<div style="display: flex; gap: var(--ml-space-3);">
+											<ml-form-field label="First Name" style="flex: 1;">
+												<ml-input placeholder="First name"></ml-input>
+											</ml-form-field>
+											<ml-form-field label="Last Name" style="flex: 1;">
+												<ml-input placeholder="Last name"></ml-input>
+											</ml-form-field>
+										</div>
+										<ml-form-field label="Email">
+											<ml-input type="email" placeholder="Enter your email"></ml-input>
+										</ml-form-field>
+										<ml-form-field label="Password">
+											<ml-input type="password" placeholder="Create a password"></ml-input>
+										</ml-form-field>
+										<ml-button variant="primary" full-width>Create Account</ml-button>
+									</div>
+									<div slot="footer" style="text-align: center; font-family: var(--ml-font-sans); font-size: var(--ml-text-sm); color: var(--ml-color-text-secondary);">
+										Already have an account? <a href="#" style="color: var(--ml-color-primary); text-decoration: none; font-weight: var(--ml-font-medium);">Log in</a>
+									</div>
+								</ml-signup-page>
+							</div>
+						</div>
+					</section>
+
+					<!-- Dashboard Page Section -->
+					<section id="dashboard-page" class="demo-section">
+						<div class="demo-section__header">
+							<h2>Dashboard Page</h2>
+							<p>Composite dashboard layout composing app shell, page header, metrics, and content areas.</p>
+						</div>
+
+						<div class="demo-card">
+							<div class="demo-card__header">
+								<h3>Full Dashboard</h3>
+								<span class="demo-card__badge">Composite layout</span>
+							</div>
+							<div style="height: 600px; border: var(--ml-border) solid var(--ml-color-border); border-radius: var(--ml-radius-lg); overflow: hidden;">
+								<ml-dashboard-page title="Dashboard" description="Overview of your account activity.">
+									<div slot="sidebar" style="padding: var(--ml-space-4); background: var(--ml-color-surface); border-right: var(--ml-border) solid var(--ml-color-border); height: 100%; box-sizing: border-box; font-family: var(--ml-font-sans);">
+										<div style="font-weight: var(--ml-font-semibold); font-size: var(--ml-text-sm); margin-bottom: var(--ml-space-4);">Navigation</div>
+										<div style="display: flex; flex-direction: column; gap: var(--ml-space-2);">
+											<span style="font-size: var(--ml-text-sm); color: var(--ml-color-primary); font-weight: var(--ml-font-medium);">Dashboard</span>
+											<span style="font-size: var(--ml-text-sm); color: var(--ml-color-text-secondary);">Projects</span>
+											<span style="font-size: var(--ml-text-sm); color: var(--ml-color-text-secondary);">Team</span>
+											<span style="font-size: var(--ml-text-sm); color: var(--ml-color-text-secondary);">Settings</span>
+										</div>
+									</div>
+									<ml-button slot="header-actions" variant="primary" size="sm">
+										<ml-icon icon="plus" size="sm"></ml-icon>New Project
+									</ml-button>
+									<div slot="metrics" style="display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--ml-space-4); font-family: var(--ml-font-sans);">
+										<ml-card>
+											<div style="padding: var(--ml-space-1);">
+												<div style="font-size: var(--ml-text-sm); color: var(--ml-color-text-secondary);">Total Revenue</div>
+												<div style="font-size: var(--ml-text-2xl); font-weight: var(--ml-font-bold); color: var(--ml-color-text); margin-top: var(--ml-space-1);">$45,231</div>
+											</div>
+										</ml-card>
+										<ml-card>
+											<div style="padding: var(--ml-space-1);">
+												<div style="font-size: var(--ml-text-sm); color: var(--ml-color-text-secondary);">Active Users</div>
+												<div style="font-size: var(--ml-text-2xl); font-weight: var(--ml-font-bold); color: var(--ml-color-text); margin-top: var(--ml-space-1);">2,350</div>
+											</div>
+										</ml-card>
+										<ml-card>
+											<div style="padding: var(--ml-space-1);">
+												<div style="font-size: var(--ml-text-sm); color: var(--ml-color-text-secondary);">Conversion Rate</div>
+												<div style="font-size: var(--ml-text-2xl); font-weight: var(--ml-font-bold); color: var(--ml-color-text); margin-top: var(--ml-space-1);">3.2%</div>
+											</div>
+										</ml-card>
+									</div>
+									<div slot="main" style="font-family: var(--ml-font-sans);">
+										<ml-card>
+											<h3 slot="header" style="font-size: var(--ml-text-base); font-weight: var(--ml-font-semibold);">Recent Activity</h3>
+											<div style="display: flex; flex-direction: column; gap: var(--ml-space-3);">
+												<div style="display: flex; align-items: center; gap: var(--ml-space-3);">
+													<ml-avatar name="Olivia Rhye" size="sm"></ml-avatar>
+													<div style="flex: 1;">
+														<div style="font-size: var(--ml-text-sm); font-weight: var(--ml-font-medium);">Olivia Rhye created a new project</div>
+														<div style="font-size: var(--ml-text-xs); color: var(--ml-color-text-muted);">2 hours ago</div>
+													</div>
+												</div>
+												<div style="display: flex; align-items: center; gap: var(--ml-space-3);">
+													<ml-avatar name="Phoenix Baker" size="sm"></ml-avatar>
+													<div style="flex: 1;">
+														<div style="font-size: var(--ml-text-sm); font-weight: var(--ml-font-medium);">Phoenix Baker updated sprint board</div>
+														<div style="font-size: var(--ml-text-xs); color: var(--ml-color-text-muted);">4 hours ago</div>
+													</div>
+												</div>
+											</div>
+										</ml-card>
+									</div>
+									<div slot="aside" style="font-family: var(--ml-font-sans);">
+										<ml-card>
+											<h3 slot="header" style="font-size: var(--ml-text-base); font-weight: var(--ml-font-semibold);">Notifications</h3>
+											<div style="font-size: var(--ml-text-sm); color: var(--ml-color-text-secondary);">
+												<p>You have 3 unread messages and 2 pending tasks.</p>
+											</div>
+										</ml-card>
+									</div>
+								</ml-dashboard-page>
 							</div>
 						</div>
 					</section>

--- a/web/demo/main.ts
+++ b/web/demo/main.ts
@@ -54,6 +54,16 @@ import '@melodicdev/components/pagination';
 import '@melodicdev/components/steps';
 import '@melodicdev/components/sidebar';
 
+// Import components - Sections
+import '@melodicdev/components/app-shell';
+import '@melodicdev/components/hero-section';
+import '@melodicdev/components/page-header';
+
+// Import components - Pages
+import '@melodicdev/components/login-page';
+import '@melodicdev/components/signup-page';
+import '@melodicdev/components/dashboard-page';
+
 // Import directives
 import '@melodicdev/components/directives';
 


### PR DESCRIPTION
Introduce a set of layout and page components: ml-app-shell (with responsive drawer/toolbar), ml-hero-section, ml-page-header, auth pages (ml-login-page, ml-signup-page) and ml-dashboard-page. Each component includes TS class, template, and styles plus index exports. Add shared auth layout CSS and wire up new package exports in melodic-components package.json. Also update demo config and main to surface the new components.