### PR TITLE
Add explicit-member-accessibility ESLint rule

### DIFF
--- a/packages/melodic-components/src/components/data-display/activity-feed/activity-feed-item.component.ts
+++ b/packages/melodic-components/src/components/data-display/activity-feed/activity-feed-item.component.ts
@@ -27,39 +27,39 @@ type IndicatorColor = 'success' | 'warning' | 'error' | 'primary' | 'gray';
 	attributes: ['name', 'timestamp', 'avatar-src', 'avatar-initials', 'avatar-size', 'subtitle', 'indicator', 'indicator-color']
 })
 export class ActivityFeedItemComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** User display name */
-	name = '';
+	public name = '';
 
 	/** Timestamp text */
-	timestamp = '';
+	public timestamp = '';
 
 	/** Avatar image source */
-	'avatar-src' = '';
+	public 'avatar-src' = '';
 
 	/** Avatar initials fallback */
-	'avatar-initials' = '';
+	public 'avatar-initials' = '';
 
 	/** Avatar size */
-	'avatar-size': Size = 'sm';
+	public 'avatar-size': Size = 'sm';
 
 	/** Subtitle text (e.g. @handle) */
-	subtitle = '';
+	public subtitle = '';
 
 	/** Show indicator dot */
-	indicator = false;
+	public indicator = false;
 
 	/** Indicator dot color */
-	'indicator-color': IndicatorColor = 'gray';
+	public 'indicator-color': IndicatorColor = 'gray';
 
 	/** Check if avatar slot has content */
-	get hasAvatarSlot(): boolean {
+	public get hasAvatarSlot(): boolean {
 		return this.elementRef?.querySelector('[slot="avatar"]') !== null;
 	}
 
 	/** Check if content slot has content */
-	get hasContentSlot(): boolean {
+	public get hasContentSlot(): boolean {
 		return this.elementRef?.querySelector('[slot="content"]') !== null;
 	}
 }

--- a/packages/melodic-components/src/components/data-display/activity-feed/activity-feed.component.ts
+++ b/packages/melodic-components/src/components/data-display/activity-feed/activity-feed.component.ts
@@ -26,8 +26,8 @@ type ActivityFeedVariant = 'list' | 'timeline';
 	attributes: ['variant']
 })
 export class ActivityFeedComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Feed display variant */
-	variant: ActivityFeedVariant = 'list';
+	public variant: ActivityFeedVariant = 'list';
 }

--- a/packages/melodic-components/src/components/data-display/avatar/avatar.component.ts
+++ b/packages/melodic-components/src/components/data-display/avatar/avatar.component.ts
@@ -23,31 +23,31 @@ import { avatarStyles } from './avatar.styles.js';
 	attributes: ['src', 'alt', 'initials', 'size', 'rounded']
 })
 export class AvatarComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Image source URL */
-	src = '';
+	public src = '';
 
 	/** Alt text for image */
-	alt = '';
+	public alt = '';
 
 	/** Initials to display (fallback if no image) */
-	initials = '';
+	public initials = '';
 
 	/** Avatar size */
-	size: Size = 'md';
+	public size: Size = 'md';
 
 	/** Use rounded square instead of circle */
-	rounded = false;
+	public rounded = false;
 
 	/** Internal: track image load errors */
-	_imageError = false;
+	public _imageError = false;
 
-	handleImageError = (): void => {
+	public handleImageError = (): void => {
 		this._imageError = true;
 	};
 
-	getInitials(): string {
+	public getInitials(): string {
 		// Return at most 2 characters
 		return this.initials.slice(0, 2).toUpperCase();
 	}

--- a/packages/melodic-components/src/components/data-display/badge-group/badge-group.component.ts
+++ b/packages/melodic-components/src/components/data-display/badge-group/badge-group.component.ts
@@ -26,23 +26,23 @@ type BadgePosition = 'leading' | 'trailing';
 	attributes: ['label', 'variant', 'theme', 'size', 'badge-position', 'icon']
 })
 export class BadgeGroupComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Inner badge label text */
-	label = '';
+	public label = '';
 
 	/** Color variant */
-	variant: BadgeVariant = 'default';
+	public variant: BadgeVariant = 'default';
 
 	/** Visual theme */
-	theme: BadgeGroupTheme = 'pill';
+	public theme: BadgeGroupTheme = 'pill';
 
 	/** Size */
-	size: 'sm' | 'md' | 'lg' = 'md';
+	public size: 'sm' | 'md' | 'lg' = 'md';
 
 	/** Position of the inner badge */
-	badgePosition: BadgePosition = 'leading';
+	public badgePosition: BadgePosition = 'leading';
 
 	/** Optional trailing icon name */
-	icon = '';
+	public icon = '';
 }

--- a/packages/melodic-components/src/components/data-display/badge/badge.component.ts
+++ b/packages/melodic-components/src/components/data-display/badge/badge.component.ts
@@ -24,17 +24,17 @@ import { badgeStyles } from './badge.styles.js';
 	attributes: ['variant', 'size', 'dot', 'pill']
 })
 export class BadgeComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Badge variant */
-	variant: BadgeVariant = 'default';
+	public variant: BadgeVariant = 'default';
 
 	/** Badge size */
-	size: Size = 'md';
+	public size: Size = 'md';
 
 	/** Show dot indicator */
-	dot = false;
+	public dot = false;
 
 	/** Use pill (rounded) shape */
-	pill = false;
+	public pill = false;
 }

--- a/packages/melodic-components/src/components/data-display/calendar-view/calendar-view.component.ts
+++ b/packages/melodic-components/src/components/data-display/calendar-view/calendar-view.component.ts
@@ -55,48 +55,48 @@ import { calendarViewStyles } from './calendar-view.styles.js';
 	]
 })
 export class CalendarViewComponent implements IElementRef, OnCreate, OnDestroy, OnRender {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Current view mode */
-	view: CalendarViewMode = 'month';
+	public view: CalendarViewMode = 'month';
 
 	/** Navigated date (ISO date string) */
-	date = '';
+	public date = '';
 
 	/** Day the week starts on (0=Sunday, 1=Monday) */
-	weekStartsOn = 0;
+	public weekStartsOn = 0;
 
 	/** Maximum visible events per day cell in month view */
-	maxVisibleEvents = 3;
+	public maxVisibleEvents = 3;
 
 	/** Label for the add event button */
-	addButtonText = 'Add event';
+	public addButtonText = 'Add event';
 
 	/** Hide prev/next navigation arrows */
-	hideNav = false;
+	public hideNav = false;
 
 	/** Hide the "Today" button */
-	hideTodayButton = false;
+	public hideTodayButton = false;
 
 	/** Hide the view dropdown */
-	hideViewSelector = false;
+	public hideViewSelector = false;
 
 	/** Hide the add event button */
-	hideAddButton = false;
+	public hideAddButton = false;
 
 	/** Calendar events (property-only) */
-	events: CalendarEvent[] = [];
+	public events: CalendarEvent[] = [];
 
 	/** Whether the view dropdown is open */
-	isViewDropdownOpen = false;
+	public isViewDropdownOpen = false;
 
 	/** Check if header-left slot has consumer content */
-	get hasHeaderLeftSlot(): boolean {
+	public get hasHeaderLeftSlot(): boolean {
 		return this.elementRef?.querySelector('[slot="header-left"]') !== null;
 	}
 
 	/** Check if header-actions slot has consumer content */
-	get hasHeaderActionsSlot(): boolean {
+	public get hasHeaderActionsSlot(): boolean {
 		return this.elementRef?.querySelector('[slot="header-actions"]') !== null;
 	}
 
@@ -113,7 +113,7 @@ export class CalendarViewComponent implements IElementRef, OnCreate, OnDestroy, 
 		return new Date();
 	}
 
-	onCreate(): void {
+	public onCreate(): void {
 		// Initialize date if not set
 		if (!this.date) {
 			const now = new Date();
@@ -138,13 +138,13 @@ export class CalendarViewComponent implements IElementRef, OnCreate, OnDestroy, 
 		document.addEventListener('click', this._boundCloseDropdown, true);
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		if (this._boundCloseDropdown) {
 			document.removeEventListener('click', this._boundCloseDropdown, true);
 		}
 	}
 
-	onRender(): void {
+	public onRender(): void {
 		// Auto-scroll time grid to ~6 AM on initial load
 		if ((this.view === 'week' || this.view === 'day') && !this._hasScrolledToTime) {
 			const shadow = this.elementRef.shadowRoot;
@@ -160,23 +160,23 @@ export class CalendarViewComponent implements IElementRef, OnCreate, OnDestroy, 
 
 	/* ── Header computed getters ── */
 
-	get todayMonthAbbrev(): string {
+	public get todayMonthAbbrev(): string {
 		return getMonthAbbrev(new Date());
 	}
 
-	get todayDayNumber(): number {
+	public get todayDayNumber(): number {
 		return new Date().getDate();
 	}
 
-	get headerTitle(): string {
+	public get headerTitle(): string {
 		return formatMonthYear(this._currentDate);
 	}
 
-	get weekNumber(): number {
+	public get weekNumber(): number {
 		return getISOWeekNumber(this._currentDate);
 	}
 
-	get headerSubtitle(): string {
+	public get headerSubtitle(): string {
 		if (this.view === 'month') {
 			return `Week ${this.weekNumber}`;
 		}
@@ -189,18 +189,18 @@ export class CalendarViewComponent implements IElementRef, OnCreate, OnDestroy, 
 		return getDayName(this._currentDate);
 	}
 
-	get currentIsoDate(): string {
+	public get currentIsoDate(): string {
 		const d = this._currentDate;
 		return toIsoDate(d.getFullYear(), d.getMonth(), d.getDate());
 	}
 
 	/* ── Month view getters ── */
 
-	get weekdayHeaders(): { short: string; full: string }[] {
+	public get weekdayHeaders(): { short: string; full: string }[] {
 		return getWeekdayHeaders(this.weekStartsOn);
 	}
 
-	get monthGrid(): CalendarDayCell[] {
+	public get monthGrid(): CalendarDayCell[] {
 		const d = this._currentDate;
 		const grid = getMonthGrid(d.getFullYear(), d.getMonth(), this.weekStartsOn);
 		// Populate events for each day cell
@@ -212,50 +212,50 @@ export class CalendarViewComponent implements IElementRef, OnCreate, OnDestroy, 
 
 	/* ── Week view getters ── */
 
-	get weekColumns(): CalendarTimeColumn[] {
+	public get weekColumns(): CalendarTimeColumn[] {
 		return getWeekColumns(this._currentDate, this.weekStartsOn, this.events);
 	}
 
-	get timeSlots(): { label: string; hour: number; minute: number }[] {
+	public get timeSlots(): { label: string; hour: number; minute: number }[] {
 		return getTimeSlots();
 	}
 
 	/* ── Day view getters ── */
 
-	get dayColumn(): CalendarTimeColumn {
+	public get dayColumn(): CalendarTimeColumn {
 		return getDayColumn(this._currentDate, this.events);
 	}
 
-	get dayEvents(): CalendarEvent[] {
+	public get dayEvents(): CalendarEvent[] {
 		return getEventsForDate(this.events, this.currentIsoDate);
 	}
 
-	get dayViewDateLabel(): string {
+	public get dayViewDateLabel(): string {
 		const d = this._currentDate;
 		return d.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' });
 	}
 
 	/* ── Mini calendar getters (day view sidebar) ── */
 
-	get miniCalendarTitle(): string {
+	public get miniCalendarTitle(): string {
 		return formatMonthYear(new Date(this._miniCalYear, this._miniCalMonth, 1));
 	}
 
-	get miniCalendarWeekdays(): string[] {
+	public get miniCalendarWeekdays(): string[] {
 		return getWeekdayHeaders(this.weekStartsOn).map((h) => h.short.charAt(0));
 	}
 
-	get miniCalendarGrid(): CalendarDayCell[] {
+	public get miniCalendarGrid(): CalendarDayCell[] {
 		return getMiniGrid(this._miniCalYear, this._miniCalMonth, this.weekStartsOn);
 	}
 
-	get miniCalendarDots(): Set<string> {
+	public get miniCalendarDots(): Set<string> {
 		return getMiniCalendarDots(this._miniCalYear, this._miniCalMonth, this.events);
 	}
 
 	/* ── Navigation handlers ── */
 
-	navigatePrev = (): void => {
+	public navigatePrev = (): void => {
 		const d = this._currentDate;
 		let next: Date;
 		if (this.view === 'month') {
@@ -268,7 +268,7 @@ export class CalendarViewComponent implements IElementRef, OnCreate, OnDestroy, 
 		this.setDate(next);
 	};
 
-	navigateNext = (): void => {
+	public navigateNext = (): void => {
 		const d = this._currentDate;
 		let next: Date;
 		if (this.view === 'month') {
@@ -281,17 +281,17 @@ export class CalendarViewComponent implements IElementRef, OnCreate, OnDestroy, 
 		this.setDate(next);
 	};
 
-	goToToday = (): void => {
+	public goToToday = (): void => {
 		this.setDate(new Date());
 	};
 
 	/* ── View dropdown ── */
 
-	toggleViewDropdown = (): void => {
+	public toggleViewDropdown = (): void => {
 		this.isViewDropdownOpen = !this.isViewDropdownOpen;
 	};
 
-	setView = (view: CalendarViewMode): void => {
+	public setView = (view: CalendarViewMode): void => {
 		this.view = view;
 		this.isViewDropdownOpen = false;
 		this._hasScrolledToTime = false;
@@ -306,7 +306,7 @@ export class CalendarViewComponent implements IElementRef, OnCreate, OnDestroy, 
 
 	/* ── Event handlers ── */
 
-	handleEventClick = (event: CalendarEvent): void => {
+	public handleEventClick = (event: CalendarEvent): void => {
 		this.elementRef.dispatchEvent(
 			new CustomEvent('ml:event-click', {
 				bubbles: true,
@@ -316,7 +316,7 @@ export class CalendarViewComponent implements IElementRef, OnCreate, OnDestroy, 
 		);
 	};
 
-	handleDateClick = (iso: string): void => {
+	public handleDateClick = (iso: string): void => {
 		this.elementRef.dispatchEvent(
 			new CustomEvent('ml:date-click', {
 				bubbles: true,
@@ -326,7 +326,7 @@ export class CalendarViewComponent implements IElementRef, OnCreate, OnDestroy, 
 		);
 	};
 
-	handleAddEvent = (): void => {
+	public handleAddEvent = (): void => {
 		this.elementRef.dispatchEvent(
 			new CustomEvent('ml:add-event', {
 				bubbles: true,
@@ -336,7 +336,7 @@ export class CalendarViewComponent implements IElementRef, OnCreate, OnDestroy, 
 		);
 	};
 
-	handleAddEventOnDate = (iso: string): void => {
+	public handleAddEventOnDate = (iso: string): void => {
 		this.elementRef.dispatchEvent(
 			new CustomEvent('ml:add-event', {
 				bubbles: true,
@@ -346,7 +346,7 @@ export class CalendarViewComponent implements IElementRef, OnCreate, OnDestroy, 
 		);
 	};
 
-	showMoreEvents = (iso: string): void => {
+	public showMoreEvents = (iso: string): void => {
 		// Switch to day view for the date
 		this.date = iso;
 		this.setView('day');
@@ -354,7 +354,7 @@ export class CalendarViewComponent implements IElementRef, OnCreate, OnDestroy, 
 
 	/* ── Mini calendar handlers ── */
 
-	miniCalPrevMonth = (): void => {
+	public miniCalPrevMonth = (): void => {
 		if (this._miniCalMonth === 0) {
 			this._miniCalMonth = 11;
 			this._miniCalYear--;
@@ -363,7 +363,7 @@ export class CalendarViewComponent implements IElementRef, OnCreate, OnDestroy, 
 		}
 	};
 
-	miniCalNextMonth = (): void => {
+	public miniCalNextMonth = (): void => {
 		if (this._miniCalMonth === 11) {
 			this._miniCalMonth = 0;
 			this._miniCalYear++;
@@ -372,7 +372,7 @@ export class CalendarViewComponent implements IElementRef, OnCreate, OnDestroy, 
 		}
 	};
 
-	handleMiniCalSelect = (iso: string): void => {
+	public handleMiniCalSelect = (iso: string): void => {
 		this.setDate(parseDate(iso));
 	};
 

--- a/packages/melodic-components/src/components/data-display/data-grid/data-grid.component.ts
+++ b/packages/melodic-components/src/components/data-display/data-grid/data-grid.component.ts
@@ -50,83 +50,83 @@ import { VirtualScroller } from '../../../utils/virtual-scroll/index.js';
 	]
 })
 export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRender, OnPropertyChange {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	// ── Attributes ───────────────────────────────────────────────────────────────
 
 	/** Enable row selection via checkboxes */
-	selectable = false;
+	public selectable = false;
 
 	/** Alternating row backgrounds */
-	striped = false;
+	public striped = false;
 
 	/** Highlight rows on hover */
-	hoverable = true;
+	public hoverable = true;
 
 	/** Grid size variant */
-	size: 'sm' | 'md' = 'md';
+	public size: 'sm' | 'md' = 'md';
 
 	/** Optional grid title shown in toolbar */
-	gridTitle = '';
+	public gridTitle = '';
 
 	/** Optional grid description shown in toolbar */
-	description = '';
+	public description = '';
 
 	/** When true, the grid renders rows as-is without sorting/filtering/pagination */
-	serverSide = false;
+	public serverSide = false;
 
 	/** Number of rows per page */
-	pageSize = 50;
+	public pageSize = 50;
 
 	/** Enable virtual scrolling (renders only visible rows) */
-	virtual = true;
+	public virtual = true;
 
 	/** Show per-column filter inputs below the header row */
-	showFilterRow = false;
+	public showFilterRow = false;
 
 	// ── Properties ───────────────────────────────────────────────────────────────
 
 	/** Column definitions */
-	columns: DataGridColumn[] = [];
+	public columns: DataGridColumn[] = [];
 
 	/** Row data */
-	rows: Record<string, unknown>[] = [];
+	public rows: Record<string, unknown>[] = [];
 
 	// ── Sort state ───────────────────────────────────────────────────────────────
 
-	sortKey = '';
-	sortDirection: SortDirection = 'asc';
+	public sortKey = '';
+	public sortDirection: SortDirection = 'asc';
 
 	// ── Filter state ─────────────────────────────────────────────────────────────
 
-	filters: Record<string, string> = {};
+	public filters: Record<string, string> = {};
 
 	// ── Selection state ──────────────────────────────────────────────────────────
 
-	selectedIndices: number[] = [];
+	public selectedIndices: number[] = [];
 
 	// ── Pagination state ─────────────────────────────────────────────────────────
 
-	currentPage = 1;
+	public currentPage = 1;
 
 	// ── Virtual scroll state (reactive — no _ prefix) ────────────────────────────
 
-	startIndex = 0;
-	endIndex = 50;
+	public startIndex = 0;
+	public endIndex = 50;
 
 	// ── Column sizing / order (reactive — no _ prefix) ───────────────────────────
 
-	colWidths: Record<string, number> = {};
-	colOrder: string[] = [];
+	public colWidths: Record<string, number> = {};
+	public colOrder: string[] = [];
 
 	// ── Resize drag state (reactive for visual feedback) ─────────────────────────
 
-	resizingKey: string | null = null;
+	public resizingKey: string | null = null;
 
 	// ── Reorder drag state (reactive) ────────────────────────────────────────────
 
-	draggingKey: string | null = null;
-	dragOverKey: string | null = null;
+	public draggingKey: string | null = null;
+	public dragOverKey: string | null = null;
 
 	// ── Private (non-reactive) DOM refs and drag intermediates ───────────────────
 	// Properties starting with _ are intentionally excluded from reactivity.
@@ -138,24 +138,24 @@ export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRe
 
 	// ── Row height by size ────────────────────────────────────────────────────────
 
-	get rowHeight(): number {
+	public get rowHeight(): number {
 		return this.size === 'sm' ? 36 : 44;
 	}
 
 	// ── Lifecycle ─────────────────────────────────────────────────────────────────
 
-	onPropertyChange(name: string, _oldVal: unknown, newVal: unknown): void {
+	public onPropertyChange(name: string, _oldVal: unknown, newVal: unknown): void {
 		if (name === 'columns' && Array.isArray(newVal)) {
 			this._syncColumnState(newVal as DataGridColumn[]);
 		}
 	}
 
-	onCreate(): void {
+	public onCreate(): void {
 		this._syncColumnState(this.columns);
 		this._attachScroller();
 	}
 
-	onRender(): void {
+	public onRender(): void {
 		this._attachScroller();
 
 		// Update CSS variable for filter row sticky offset
@@ -184,7 +184,7 @@ export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRe
 		}
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this._scroller.detach();
 		this._viewport = null;
 	}
@@ -216,7 +216,7 @@ export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRe
 
 	// ── Data pipeline ─────────────────────────────────────────────────────────────
 
-	get filteredRows(): Record<string, unknown>[] {
+	public get filteredRows(): Record<string, unknown>[] {
 		if (this.serverSide) return this.rows;
 		const entries = Object.entries(this.filters).filter(([, v]) => v !== '');
 		if (!entries.length) return this.rows;
@@ -227,7 +227,7 @@ export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRe
 		);
 	}
 
-	get sortedRows(): Record<string, unknown>[] {
+	public get sortedRows(): Record<string, unknown>[] {
 		if (this.serverSide || !this.sortKey) return this.filteredRows;
 		const key = this.sortKey;
 		const dir = this.sortDirection === 'asc' ? 1 : -1;
@@ -241,32 +241,32 @@ export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRe
 		});
 	}
 
-	get pagedRows(): Record<string, unknown>[] {
+	public get pagedRows(): Record<string, unknown>[] {
 		if (this.serverSide) return this.rows;
 		const start = (this.currentPage - 1) * this.pageSize;
 		return this.sortedRows.slice(start, start + this.pageSize);
 	}
 
-	get processedRows(): Record<string, unknown>[] {
+	public get processedRows(): Record<string, unknown>[] {
 		return this.pagedRows;
 	}
 
-	get visibleRows(): Record<string, unknown>[] {
+	public get visibleRows(): Record<string, unknown>[] {
 		if (!this.virtual) return this.processedRows;
 		return this.processedRows.slice(this.startIndex, this.endIndex);
 	}
 
-	get totalRows(): number {
+	public get totalRows(): number {
 		return this.serverSide ? this.rows.length : this.filteredRows.length;
 	}
 
-	get totalPages(): number {
+	public get totalPages(): number {
 		return Math.max(1, Math.ceil(this.totalRows / this.pageSize));
 	}
 
 	// ── Column helpers ────────────────────────────────────────────────────────────
 
-	get orderedColumns(): DataGridColumn[] {
+	public get orderedColumns(): DataGridColumn[] {
 		if (!this.colOrder.length) return this.columns;
 		const colMap = new Map(this.columns.map(c => [c.key, c]));
 		return this.colOrder
@@ -274,7 +274,7 @@ export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRe
 			.map(k => colMap.get(k)!);
 	}
 
-	get columnWidths(): Record<string, number> {
+	public get columnWidths(): Record<string, number> {
 		const result: Record<string, number> = {};
 		for (const col of this.columns) {
 			result[col.key] = this.colWidths[col.key] ?? col.width ?? 150;
@@ -282,7 +282,7 @@ export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRe
 		return result;
 	}
 
-	get totalGridWidth(): number {
+	public get totalGridWidth(): number {
 		const colTotal = this.orderedColumns.reduce(
 			(sum, col) => sum + (this.columnWidths[col.key] ?? 150),
 			0
@@ -290,14 +290,14 @@ export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRe
 		return colTotal + (this.selectable ? 44 : 0);
 	}
 
-	get gridTemplateColumns(): string {
+	public get gridTemplateColumns(): string {
 		const cols = this.orderedColumns
 			.map(col => `${this.columnWidths[col.key] ?? 150}px`)
 			.join(' ');
 		return this.selectable ? `44px ${cols}` : cols;
 	}
 
-	getPinnedLeftOffset(key: string): number {
+	public getPinnedLeftOffset(key: string): number {
 		let offset = this.selectable ? 44 : 0;
 		for (const col of this.orderedColumns) {
 			if (col.key === key) return offset;
@@ -308,30 +308,30 @@ export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRe
 		return 0;
 	}
 
-	get topSpacerHeight(): number {
+	public get topSpacerHeight(): number {
 		return this.virtual ? this.startIndex * this.rowHeight : 0;
 	}
 
-	get bottomSpacerHeight(): number {
+	public get bottomSpacerHeight(): number {
 		if (!this.virtual) return 0;
 		return Math.max(0, (this.processedRows.length - this.endIndex) * this.rowHeight);
 	}
 
 	// ── Selection ─────────────────────────────────────────────────────────────────
 
-	get allSelected(): boolean {
+	public get allSelected(): boolean {
 		return this.processedRows.length > 0 && this.selectedIndices.length === this.processedRows.length;
 	}
 
-	get someSelected(): boolean {
+	public get someSelected(): boolean {
 		return this.selectedIndices.length > 0 && !this.allSelected;
 	}
 
-	isRowSelected = (index: number): boolean => this.selectedIndices.includes(index);
+	public isRowSelected = (index: number): boolean => this.selectedIndices.includes(index);
 
 	// ── Event handlers ────────────────────────────────────────────────────────────
 
-	handleSort = (col: DataGridColumn): void => {
+	public handleSort = (col: DataGridColumn): void => {
 		if (!col.sortable) return;
 		if (this.sortKey === col.key) {
 			this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
@@ -350,7 +350,7 @@ export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRe
 		);
 	};
 
-	handleFilterInput = (key: string, e: Event): void => {
+	public handleFilterInput = (key: string, e: Event): void => {
 		const val = (e.target as HTMLInputElement).value;
 		this.filters = { ...this.filters, [key]: val };
 		this.currentPage = 1;
@@ -364,12 +364,12 @@ export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRe
 		);
 	};
 
-	handleSelectAll = (): void => {
+	public handleSelectAll = (): void => {
 		this.selectedIndices = this.allSelected ? [] : this.processedRows.map((_, i) => i);
 		this._emitSelect();
 	};
 
-	handleSelectRow = (index: number, e: Event): void => {
+	public handleSelectRow = (index: number, e: Event): void => {
 		e.stopPropagation();
 		this.selectedIndices = this.selectedIndices.includes(index)
 			? this.selectedIndices.filter(i => i !== index)
@@ -377,7 +377,7 @@ export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRe
 		this._emitSelect();
 	};
 
-	handleRowClick = (row: Record<string, unknown>, index: number): void => {
+	public handleRowClick = (row: Record<string, unknown>, index: number): void => {
 		this.elementRef.dispatchEvent(
 			new CustomEvent('ml:row-click', {
 				bubbles: true,
@@ -387,7 +387,7 @@ export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRe
 		);
 	};
 
-	handleResizeStart = (key: string, e: PointerEvent): void => {
+	public handleResizeStart = (key: string, e: PointerEvent): void => {
 		this.resizingKey = key;
 		this._resizeStartX = e.clientX;
 		this._resizeStartWidth = this.columnWidths[key] ?? 150;
@@ -396,7 +396,7 @@ export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRe
 		e.preventDefault();
 	};
 
-	handleResizeMove = (key: string, e: PointerEvent): void => {
+	public handleResizeMove = (key: string, e: PointerEvent): void => {
 		if (this.resizingKey !== key) return;
 		const delta = e.clientX - this._resizeStartX;
 		const col = this.columns.find(c => c.key === key);
@@ -407,7 +407,7 @@ export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRe
 		};
 	};
 
-	handleResizeEnd = (): void => {
+	public handleResizeEnd = (): void => {
 		if (!this.resizingKey) return;
 		this.elementRef.dispatchEvent(
 			new CustomEvent('ml:column-resize', {
@@ -419,22 +419,22 @@ export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRe
 		this.resizingKey = null;
 	};
 
-	handleDragStart = (key: string, e: DragEvent): void => {
+	public handleDragStart = (key: string, e: DragEvent): void => {
 		this.draggingKey = key;
 		if (e.dataTransfer) e.dataTransfer.effectAllowed = 'move';
 	};
 
-	handleDragOver = (key: string, e: DragEvent): void => {
+	public handleDragOver = (key: string, e: DragEvent): void => {
 		e.preventDefault();
 		if (this.dragOverKey !== key) this.dragOverKey = key;
 	};
 
-	handleDragEnd = (): void => {
+	public handleDragEnd = (): void => {
 		this.draggingKey = null;
 		this.dragOverKey = null;
 	};
 
-	handleDrop = (targetKey: string): void => {
+	public handleDrop = (targetKey: string): void => {
 		if (!this.draggingKey || this.draggingKey === targetKey) {
 			this.draggingKey = null;
 			this.dragOverKey = null;
@@ -460,7 +460,7 @@ export class DataGridComponent implements IElementRef, OnCreate, OnDestroy, OnRe
 		this.dragOverKey = null;
 	};
 
-	goToPage = (page: number): void => {
+	public goToPage = (page: number): void => {
 		if (page < 1 || page > this.totalPages) return;
 		this.currentPage = page;
 		if (this._viewport) this._viewport.scrollTop = 0;

--- a/packages/melodic-components/src/components/data-display/list/list-item.component.ts
+++ b/packages/melodic-components/src/components/data-display/list/list-item.component.ts
@@ -25,27 +25,27 @@ import { listItemStyles } from './list-item.styles.js';
 	attributes: ['primary', 'secondary', 'disabled', 'interactive']
 })
 export class ListItemComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Primary text */
-	primary = '';
+	public primary = '';
 
 	/** Secondary text */
-	secondary = '';
+	public secondary = '';
 
 	/** Disable the item */
-	disabled = false;
+	public disabled = false;
 
 	/** Enable hover/focus states for clickable items */
-	interactive = false;
+	public interactive = false;
 
 	/** Check if leading slot has content */
-	get hasLeadingSlot(): boolean {
+	public get hasLeadingSlot(): boolean {
 		return this.elementRef?.querySelector('[slot="leading"]') !== null;
 	}
 
 	/** Check if trailing slot has content */
-	get hasTrailingSlot(): boolean {
+	public get hasTrailingSlot(): boolean {
 		return this.elementRef?.querySelector('[slot="trailing"]') !== null;
 	}
 

--- a/packages/melodic-components/src/components/data-display/list/list.component.ts
+++ b/packages/melodic-components/src/components/data-display/list/list.component.ts
@@ -27,11 +27,11 @@ type ListSize = 'sm' | 'md' | 'lg';
 	attributes: ['variant', 'size']
 })
 export class ListComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** List display variant */
-	variant: ListVariant = 'default';
+	public variant: ListVariant = 'default';
 
 	/** List size (controls item padding) */
-	size: ListSize = 'md';
+	public size: ListSize = 'md';
 }

--- a/packages/melodic-components/src/components/data-display/table/table.component.ts
+++ b/packages/melodic-components/src/components/data-display/table/table.component.ts
@@ -39,60 +39,60 @@ EventTarget.prototype.addEventListener = function (type: string, listener: Event
 	attributes: ['selectable', 'striped', 'hoverable', 'size', 'table-title', 'description', 'sticky-header', 'virtual']
 })
 export class TableComponent implements IElementRef, OnCreate, OnDestroy, OnRender, OnPropertyChange {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Whether a row-click listener is attached (auto-detected) */
-	_rowClickable = false;
+	public _rowClickable = false;
 
 	/** Whether the footer slot has content */
-	hasFooter = false;
+	public hasFooter = false;
 
 	/** Whether the header-actions slot has content */
-	hasHeaderActions = false;
+	public hasHeaderActions = false;
 
 	/** Enable row selection via checkboxes */
-	selectable = false;
+	public selectable = false;
 
 	/** Alternating row backgrounds */
-	striped = false;
+	public striped = false;
 
 	/** Highlight rows on hover */
-	hoverable = true;
+	public hoverable = true;
 
 	/** Sticky table header */
-	stickyHeader = false;
+	public stickyHeader = false;
 
 	/** Table size */
-	size: 'sm' | 'md' = 'md';
+	public size: 'sm' | 'md' = 'md';
 
 	/** Table header title */
-	tableTitle = '';
+	public tableTitle = '';
 
 	/** Table header description */
-	description = '';
+	public description = '';
 
 	/** Enable virtual scrolling (renders only visible rows) */
-	virtual = false;
+	public virtual = false;
 
 	/** Column definitions */
-	columns: TableColumn[] = [];
+	public columns: TableColumn[] = [];
 
 	/** Row data */
-	rows: Record<string, unknown>[] = [];
+	public rows: Record<string, unknown>[] = [];
 
 	/** Currently sorted column key */
-	sortKey = '';
+	public sortKey = '';
 
 	/** Current sort direction */
-	sortDirection: SortDirection = 'asc';
+	public sortDirection: SortDirection = 'asc';
 
 	/** Indices of selected rows */
-	selectedIndices: number[] = [];
+	public selectedIndices: number[] = [];
 
 	// ── Virtual scroll state ─────────────────────────────────────────────────────
 
-	startIndex = 0;
-	endIndex = 50;
+	public startIndex = 0;
+	public endIndex = 50;
 
 	// ── Private ──────────────────────────────────────────────────────────────────
 
@@ -101,23 +101,23 @@ export class TableComponent implements IElementRef, OnCreate, OnDestroy, OnRende
 
 	// ── Row height by size ────────────────────────────────────────────────────────
 
-	get rowHeight(): number {
+	public get rowHeight(): number {
 		return this.size === 'sm' ? 36 : 44;
 	}
 
 	// ── Lifecycle ─────────────────────────────────────────────────────────────────
 
-	onPropertyChange(name: string, _oldVal: unknown, _newVal: unknown): void {
+	public onPropertyChange(name: string, _oldVal: unknown, _newVal: unknown): void {
 		if (name === 'rows' || name === 'columns') {
 			this._scroller.invalidate();
 		}
 	}
 
-	onInit(): void {
+	public onInit(): void {
 		this._rowClickable = _rowClickTargets.has(this.elementRef);
 	}
 
-	onCreate(): void {
+	public onCreate(): void {
 		const shadow = this.elementRef.shadowRoot;
 		if (!shadow) return;
 		shadow.querySelectorAll('slot').forEach(slot => {
@@ -133,7 +133,7 @@ export class TableComponent implements IElementRef, OnCreate, OnDestroy, OnRende
 		this._attachScroller();
 	}
 
-	onRender(): void {
+	public onRender(): void {
 		this._attachScroller();
 
 		// Compute initial end index when viewport height not yet known
@@ -150,7 +150,7 @@ export class TableComponent implements IElementRef, OnCreate, OnDestroy, OnRende
 		}
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this._scroller.detach();
 		this._viewport = null;
 	}
@@ -174,7 +174,7 @@ export class TableComponent implements IElementRef, OnCreate, OnDestroy, OnRende
 	// ── Data ──────────────────────────────────────────────────────────────────────
 
 	/** Rows sorted by current sort key/direction */
-	get sortedRows(): Record<string, unknown>[] {
+	public get sortedRows(): Record<string, unknown>[] {
 		if (!this.sortKey) return this.rows;
 		const key = this.sortKey;
 		const dir = this.sortDirection === 'asc' ? 1 : -1;
@@ -190,39 +190,39 @@ export class TableComponent implements IElementRef, OnCreate, OnDestroy, OnRende
 		});
 	}
 
-	get visibleRows(): Record<string, unknown>[] {
+	public get visibleRows(): Record<string, unknown>[] {
 		if (!this.virtual) return this.sortedRows;
 		return this.sortedRows.slice(this.startIndex, this.endIndex);
 	}
 
-	get topSpacerHeight(): number {
+	public get topSpacerHeight(): number {
 		return this.virtual ? this.startIndex * this.rowHeight : 0;
 	}
 
-	get bottomSpacerHeight(): number {
+	public get bottomSpacerHeight(): number {
 		if (!this.virtual) return 0;
 		return Math.max(0, (this.sortedRows.length - this.endIndex) * this.rowHeight);
 	}
 
-	get colCount(): number {
+	public get colCount(): number {
 		return this.columns.length + (this.selectable ? 1 : 0);
 	}
 
-	get allSelected(): boolean {
+	public get allSelected(): boolean {
 		return this.rows.length > 0 && this.selectedIndices.length === this.rows.length;
 	}
 
-	get someSelected(): boolean {
+	public get someSelected(): boolean {
 		return this.selectedIndices.length > 0 && !this.allSelected;
 	}
 
-	isRowSelected = (index: number): boolean => {
+	public isRowSelected = (index: number): boolean => {
 		return this.selectedIndices.includes(index);
 	};
 
 	// ── Event handlers ────────────────────────────────────────────────────────────
 
-	handleSort = (column: TableColumn): void => {
+	public handleSort = (column: TableColumn): void => {
 		if (!column.sortable) return;
 		if (this.sortKey === column.key) {
 			this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
@@ -241,7 +241,7 @@ export class TableComponent implements IElementRef, OnCreate, OnDestroy, OnRende
 		);
 	};
 
-	handleSelectAll = (): void => {
+	public handleSelectAll = (): void => {
 		if (this.allSelected) {
 			this.selectedIndices = [];
 		} else {
@@ -250,7 +250,7 @@ export class TableComponent implements IElementRef, OnCreate, OnDestroy, OnRende
 		this.emitSelect();
 	};
 
-	handleSelectRow = (index: number, event: Event): void => {
+	public handleSelectRow = (index: number, event: Event): void => {
 		event.stopPropagation();
 		if (this.selectedIndices.includes(index)) {
 			this.selectedIndices = this.selectedIndices.filter(i => i !== index);
@@ -260,7 +260,7 @@ export class TableComponent implements IElementRef, OnCreate, OnDestroy, OnRende
 		this.emitSelect();
 	};
 
-	handleRowClick = (row: Record<string, unknown>, index: number): void => {
+	public handleRowClick = (row: Record<string, unknown>, index: number): void => {
 		this.elementRef.dispatchEvent(
 			new CustomEvent('ml:row-click', {
 				bubbles: true,

--- a/packages/melodic-components/src/components/data-display/tag/tag.component.ts
+++ b/packages/melodic-components/src/components/data-display/tag/tag.component.ts
@@ -28,40 +28,40 @@ import { tagStyles } from './tag.styles.js';
 	attributes: ['size', 'dot', 'dot-color', 'closable', 'avatar-src', 'icon', 'count', 'checkable', 'checked', 'disabled']
 })
 export class TagComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Tag size */
-	size: Size = 'md';
+	public size: Size = 'md';
 
 	/** Show dot indicator */
-	dot = false;
+	public dot = false;
 
 	/** Dot color */
-	'dot-color': TagDotColor = 'success';
+	public 'dot-color': TagDotColor = 'success';
 
 	/** Show close button */
-	closable = false;
+	public closable = false;
 
 	/** Avatar image source */
-	'avatar-src' = '';
+	public 'avatar-src' = '';
 
 	/** Icon name (Phosphor icon) */
-	icon = '';
+	public icon = '';
 
 	/** Count value displayed on the right */
-	count = '';
+	public count = '';
 
 	/** Show checkbox */
-	checkable = false;
+	public checkable = false;
 
 	/** Checkbox checked state */
-	checked = false;
+	public checked = false;
 
 	/** Disabled state */
-	disabled = false;
+	public disabled = false;
 
 	/** Handle close button click */
-	handleClose = (event: Event): void => {
+	public handleClose = (event: Event): void => {
 		event.stopPropagation();
 		if (this.disabled) return;
 
@@ -74,7 +74,7 @@ export class TagComponent implements IElementRef {
 	};
 
 	/** Handle checkbox change */
-	handleCheck = (event: Event): void => {
+	public handleCheck = (event: Event): void => {
 		event.stopPropagation();
 		if (this.disabled) return;
 

--- a/packages/melodic-components/src/components/feedback/alert/alert.component.ts
+++ b/packages/melodic-components/src/components/feedback/alert/alert.component.ts
@@ -29,18 +29,18 @@ import { alertStyles } from './alert.styles.js';
 	attributes: ['variant', 'title', 'dismissible']
 })
 export class AlertComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Alert variant/type */
-	variant: AlertVariant = 'info';
+	public variant: AlertVariant = 'info';
 
 	/** Optional title */
-	title = '';
+	public title = '';
 
 	/** Show dismiss button */
-	dismissible = false;
+	public dismissible = false;
 
-	handleDismiss = (): void => {
+	public handleDismiss = (): void => {
 		this.elementRef.dispatchEvent(
 			new CustomEvent('ml:dismiss', {
 				bubbles: true,
@@ -51,7 +51,7 @@ export class AlertComponent implements IElementRef {
 		this.elementRef.setAttribute('hidden', '');
 	};
 
-	renderDefaultIcon = () => {
+	public renderDefaultIcon = () => {
 		const icons: Record<AlertVariant, string> = {
 			info: 'info',
 			success: 'check-circle',

--- a/packages/melodic-components/src/components/feedback/progress/progress.component.ts
+++ b/packages/melodic-components/src/components/feedback/progress/progress.component.ts
@@ -26,82 +26,82 @@ type ProgressLabelPosition = 'top' | 'right' | 'bottom' | 'floating-top' | 'floa
 	attributes: ['value', 'max', 'variant', 'size', 'label', 'show-value', 'shape', 'label-position']
 })
 export class ProgressComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Current value (0-max) */
-	value = 0;
+	public value = 0;
 
 	/** Maximum value */
-	max = 100;
+	public max = 100;
 
 	/** Color variant */
-	variant: ProgressVariant = 'primary';
+	public variant: ProgressVariant = 'primary';
 
 	/** Bar height / circle size */
-	size: ProgressSize = 'md';
+	public size: ProgressSize = 'md';
 
 	/** Optional label */
-	label = '';
+	public label = '';
 
 	/** Show percentage text */
-	showValue = false;
+	public showValue = false;
 
 	/** Shape: linear bar, full circle, or half circle */
-	shape: ProgressShape = 'linear';
+	public shape: ProgressShape = 'linear';
 
 	/** Label position for linear bars */
-	labelPosition: ProgressLabelPosition = 'top';
+	public labelPosition: ProgressLabelPosition = 'top';
 
-	get percentage(): number {
+	public get percentage(): number {
 		const max = Math.max(this.max, 1);
 		return Math.min(Math.max((this.value / max) * 100, 0), 100);
 	}
 
-	get displayValue(): string {
+	public get displayValue(): string {
 		return `${Math.round(this.percentage)}%`;
 	}
 
 	/** SVG circle radius based on size */
-	get circleRadius(): number {
+	public get circleRadius(): number {
 		if (this.size === 'sm') return 28;
 		if (this.size === 'lg') return 52;
 		return 40;
 	}
 
 	/** SVG stroke width based on size */
-	get circleStroke(): number {
+	public get circleStroke(): number {
 		if (this.size === 'sm') return 4;
 		if (this.size === 'lg') return 8;
 		return 6;
 	}
 
 	/** Full circumference for stroke-dasharray */
-	get circumference(): number {
+	public get circumference(): number {
 		return 2 * Math.PI * this.circleRadius;
 	}
 
 	/** Half circumference for half-circle */
-	get halfCircumference(): number {
+	public get halfCircumference(): number {
 		return Math.PI * this.circleRadius;
 	}
 
 	/** Dash offset for full circle */
-	get circleDashOffset(): number {
+	public get circleDashOffset(): number {
 		return this.circumference - (this.percentage / 100) * this.circumference;
 	}
 
 	/** Dash offset for half circle */
-	get halfCircleDashOffset(): number {
+	public get halfCircleDashOffset(): number {
 		return this.halfCircumference - (this.percentage / 100) * this.halfCircumference;
 	}
 
 	/** SVG viewBox size */
-	get svgSize(): number {
+	public get svgSize(): number {
 		return (this.circleRadius + this.circleStroke) * 2;
 	}
 
 	/** SVG center point */
-	get svgCenter(): number {
+	public get svgCenter(): number {
 		return this.circleRadius + this.circleStroke;
 	}
 }

--- a/packages/melodic-components/src/components/feedback/spinner/spinner.component.ts
+++ b/packages/melodic-components/src/components/feedback/spinner/spinner.component.ts
@@ -21,11 +21,11 @@ import { spinnerStyles } from './spinner.styles.js';
 	attributes: ['size', 'label']
 })
 export class SpinnerComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Size of the spinner */
-	size: Size = 'md';
+	public size: Size = 'md';
 
 	/** Accessible label for screen readers */
-	label = 'Loading';
+	public label = 'Loading';
 }

--- a/packages/melodic-components/src/components/feedback/toast/toast-container.component.ts
+++ b/packages/melodic-components/src/components/feedback/toast/toast-container.component.ts
@@ -17,8 +17,8 @@ import { toastContainerStyles } from './toast-container.styles.js';
 	attributes: ['position']
 })
 export class ToastContainerComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Fixed position on screen */
-	position: ToastPosition = 'top-right';
+	public position: ToastPosition = 'top-right';
 }

--- a/packages/melodic-components/src/components/feedback/toast/toast.component.ts
+++ b/packages/melodic-components/src/components/feedback/toast/toast.component.ts
@@ -21,32 +21,32 @@ import { toastStyles } from './toast.styles.js';
 	attributes: ['variant', 'title', 'message', 'duration', 'dismissible']
 })
 export class ToastComponent implements IElementRef, OnCreate {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Toast variant */
-	variant: ToastVariant = 'info';
+	public variant: ToastVariant = 'info';
 
 	/** Toast title */
-	title = '';
+	public title = '';
 
 	/** Toast message */
-	message = '';
+	public message = '';
 
 	/** Auto-dismiss duration in ms (0 = no auto-dismiss) */
-	duration = 5000;
+	public duration = 5000;
 
 	/** Show dismiss button */
-	dismissible = true;
+	public dismissible = true;
 
 	private _timer: ReturnType<typeof setTimeout> | null = null;
 
-	onCreate(): void {
+	public onCreate(): void {
 		if (this.duration > 0) {
 			this._timer = setTimeout(() => this.dismiss(), this.duration);
 		}
 	}
 
-	dismiss = (): void => {
+	public dismiss = (): void => {
 		if (this._timer) {
 			clearTimeout(this._timer);
 			this._timer = null;
@@ -62,7 +62,7 @@ export class ToastComponent implements IElementRef, OnCreate {
 		this.elementRef.remove();
 	};
 
-	renderIcon = () => {
+	public renderIcon = () => {
 		const icons: Record<ToastVariant, string> = {
 			info: 'info',
 			success: 'check-circle',

--- a/packages/melodic-components/src/components/feedback/toast/toast.service.ts
+++ b/packages/melodic-components/src/components/feedback/toast/toast.service.ts
@@ -20,7 +20,7 @@ export class ToastService {
 	private _position: ToastPosition = 'top-right';
 
 	/** Set the default position for all toasts */
-	setPosition(position: ToastPosition): void {
+	public setPosition(position: ToastPosition): void {
 		this._position = position;
 
 		if (this._containerEl) {
@@ -29,7 +29,7 @@ export class ToastService {
 	}
 
 	/** Show a toast with full configuration */
-	show(config: IToastConfig): void {
+	public show(config: IToastConfig): void {
 		const container = this.ensureContainer();
 		const toast = document.createElement('ml-toast');
 
@@ -43,22 +43,22 @@ export class ToastService {
 	}
 
 	/** Show an info toast */
-	info(title: string, message?: string): void {
+	public info(title: string, message?: string): void {
 		this.show({ variant: 'info', title, message });
 	}
 
 	/** Show a success toast */
-	success(title: string, message?: string): void {
+	public success(title: string, message?: string): void {
 		this.show({ variant: 'success', title, message });
 	}
 
 	/** Show a warning toast */
-	warning(title: string, message?: string): void {
+	public warning(title: string, message?: string): void {
 		this.show({ variant: 'warning', title, message });
 	}
 
 	/** Show an error toast */
-	error(title: string, message?: string): void {
+	public error(title: string, message?: string): void {
 		this.show({ variant: 'error', title, message });
 	}
 

--- a/packages/melodic-components/src/components/forms/autocomplete/autocomplete.component.ts
+++ b/packages/melodic-components/src/components/forms/autocomplete/autocomplete.component.ts
@@ -39,67 +39,67 @@ import { autocompleteStyles } from './autocomplete.styles.js';
 	attributes: ['label', 'placeholder', 'hint', 'error', 'size', 'disabled', 'required', 'value', 'multiple']
 })
 export class AutocompleteComponent implements IElementRef, OnCreate, OnDestroy {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Label text */
-	label = '';
+	public label = '';
 
 	/** Placeholder text */
-	placeholder = 'Search';
+	public placeholder = 'Search';
 
 	/** Hint text shown below input */
-	hint = '';
+	public hint = '';
 
 	/** Error message (shows error state when set) */
-	error = '';
+	public error = '';
 
 	/** Component size */
-	size: Size = 'md';
+	public size: Size = 'md';
 
 	/** Disable the component */
-	disabled = false;
+	public disabled = false;
 
 	/** Mark as required */
-	required = false;
+	public required = false;
 
 	/** Enable multi-select mode */
-	multiple = false;
+	public multiple = false;
 
 	/** Currently selected value (single mode) */
-	value = '';
+	public value = '';
 
 	/** Currently selected values (multi mode) */
-	values: string[] = [];
+	public values: string[] = [];
 
 	/** Static options list */
-	options: AutocompleteOption[] = [];
+	public options: AutocompleteOption[] = [];
 
 	/** Async search function */
-	searchFn: AutocompleteSearchFn | null = null;
+	public searchFn: AutocompleteSearchFn | null = null;
 
 	/** Debounce ms for async search */
-	debounce = 300;
+	public debounce = 300;
 
 	/** Min chars before searching (0 = show on focus) */
-	minChars = 0;
+	public minChars = 0;
 
 	/** Show search icon */
-	showIcon = true;
+	public showIcon = true;
 
 	/** Current search query */
-	search = '';
+	public search = '';
 
 	/** Whether dropdown is open */
-	isOpen = false;
+	public isOpen = false;
 
 	/** Currently focused option index */
-	focusedIndex = -1;
+	public focusedIndex = -1;
 
 	/** Loading state for async search */
-	loading = false;
+	public loading = false;
 
 	/** Resolved async results */
-	asyncOptions: AutocompleteOption[] = [];
+	public asyncOptions: AutocompleteOption[] = [];
 
 	private readonly _handleKeyDown = this.onKeyDown.bind(this);
 	private readonly _handleDocumentClick = this.onDocumentClick.bind(this);
@@ -107,11 +107,11 @@ export class AutocompleteComponent implements IElementRef, OnCreate, OnDestroy {
 	private _debounceTimer: ReturnType<typeof setTimeout> | null = null;
 	private _syncingValues = false;
 
-	onCreate(): void {
+	public onCreate(): void {
 		this.elementRef.addEventListener('keydown', this._handleKeyDown);
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this.elementRef.removeEventListener('keydown', this._handleKeyDown);
 		this.removeScrollListener();
 		this.removeDocumentClickListener();
@@ -120,7 +120,7 @@ export class AutocompleteComponent implements IElementRef, OnCreate, OnDestroy {
 		}
 	}
 
-	onPropertyChange(name: string): void {
+	public onPropertyChange(name: string): void {
 		if (this._syncingValues) return;
 
 		if (name === 'multiple') {
@@ -171,13 +171,13 @@ export class AutocompleteComponent implements IElementRef, OnCreate, OnDestroy {
 	}
 
 	/** Get the selected option (single mode) */
-	get selectedOption(): AutocompleteOption | undefined {
+	public get selectedOption(): AutocompleteOption | undefined {
 		return this.allOptions.find((opt) => opt.value === this.value)
 			?? this.options.find((opt) => opt.value === this.value);
 	}
 
 	/** Get selected options (multi mode) */
-	get selectedOptions(): AutocompleteOption[] {
+	public get selectedOptions(): AutocompleteOption[] {
 		if (!this.multiple) {
 			return this.selectedOption ? [this.selectedOption] : [];
 		}
@@ -188,12 +188,12 @@ export class AutocompleteComponent implements IElementRef, OnCreate, OnDestroy {
 	}
 
 	/** All available options (static or async) */
-	get allOptions(): AutocompleteOption[] {
+	public get allOptions(): AutocompleteOption[] {
 		return this.searchFn ? this.asyncOptions : this.options;
 	}
 
 	/** Filtered options for display */
-	get filteredOptions(): AutocompleteOption[] {
+	public get filteredOptions(): AutocompleteOption[] {
 		if (this.searchFn) {
 			return this.asyncOptions;
 		}
@@ -209,18 +209,18 @@ export class AutocompleteComponent implements IElementRef, OnCreate, OnDestroy {
 		});
 	}
 
-	get hasValue(): boolean {
+	public get hasValue(): boolean {
 		return this.multiple ? this.values.length > 0 : !!this.value;
 	}
 
 	/** Display text for the input in single mode */
-	get displayText(): string {
+	public get displayText(): string {
 		if (this.multiple) return '';
 		return this.selectedOption?.label || '';
 	}
 
 	/** Open the dropdown */
-	open = (): void => {
+	public open = (): void => {
 		if (this.disabled || this.isOpen) return;
 		if (this.minChars > 0 && this.search.length < this.minChars) return;
 
@@ -240,7 +240,7 @@ export class AutocompleteComponent implements IElementRef, OnCreate, OnDestroy {
 	};
 
 	/** Close the dropdown */
-	close = (): void => {
+	public close = (): void => {
 		if (!this.isOpen) return;
 
 		this.getDropdownEl()?.hidePopover();
@@ -255,7 +255,7 @@ export class AutocompleteComponent implements IElementRef, OnCreate, OnDestroy {
 	};
 
 	/** Select an option */
-	selectOption = (option: AutocompleteOption): void => {
+	public selectOption = (option: AutocompleteOption): void => {
 		if (option.disabled) return;
 
 		if (this.multiple) {
@@ -277,13 +277,13 @@ export class AutocompleteComponent implements IElementRef, OnCreate, OnDestroy {
 	};
 
 	/** Handle click on option */
-	handleOptionClick = (event: Event, option: AutocompleteOption): void => {
+	public handleOptionClick = (event: Event, option: AutocompleteOption): void => {
 		event.stopPropagation();
 		this.selectOption(option);
 	};
 
 	/** Handle input changes */
-	handleInput = (event: Event): void => {
+	public handleInput = (event: Event): void => {
 		if (this.disabled) return;
 		const target = event.target as HTMLInputElement;
 		this.search = target.value;
@@ -325,7 +325,7 @@ export class AutocompleteComponent implements IElementRef, OnCreate, OnDestroy {
 	};
 
 	/** Handle input focus */
-	handleFocus = (): void => {
+	public handleFocus = (): void => {
 		if (this.disabled) return;
 
 		if (this.minChars === 0) {
@@ -339,7 +339,7 @@ export class AutocompleteComponent implements IElementRef, OnCreate, OnDestroy {
 	};
 
 	/** Handle input click */
-	handleInputClick = (event: Event): void => {
+	public handleInputClick = (event: Event): void => {
 		event.stopPropagation();
 		if (!this.isOpen && this.minChars === 0) {
 			if (this.searchFn && this.asyncOptions.length === 0) {
@@ -350,7 +350,7 @@ export class AutocompleteComponent implements IElementRef, OnCreate, OnDestroy {
 	};
 
 	/** Handle tag remove in multi mode */
-	handleTagRemove = (event: Event, value: string): void => {
+	public handleTagRemove = (event: Event, value: string): void => {
 		event.stopPropagation();
 		if (this.disabled) return;
 
@@ -365,7 +365,7 @@ export class AutocompleteComponent implements IElementRef, OnCreate, OnDestroy {
 	};
 
 	/** Clear the current value (single mode) */
-	handleClear = (event: Event): void => {
+	public handleClear = (event: Event): void => {
 		event.stopPropagation();
 		if (this.disabled) return;
 

--- a/packages/melodic-components/src/components/forms/button-group/button-group-item.component.ts
+++ b/packages/melodic-components/src/components/forms/button-group/button-group-item.component.ts
@@ -21,31 +21,31 @@ import { buttonGroupItemStyles } from './button-group-item.styles.js';
 	attributes: ['value', 'icon', 'disabled', 'active', 'group-disabled', 'group-size']
 })
 export class ButtonGroupItemComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Item value identifier */
-	value = '';
+	public value = '';
 
 	/** Optional icon name */
-	icon = '';
+	public icon = '';
 
 	/** Disable this item */
-	disabled = false;
+	public disabled = false;
 
 	/** Active state (managed by parent via attribute) */
-	active = false;
+	public active = false;
 
 	/** Disabled state from parent group */
-	groupDisabled = false;
+	public groupDisabled = false;
 
 	/** Size from parent group */
-	groupSize: Size = 'md';
+	public groupSize: Size = 'md';
 
-	get isDisabled(): boolean {
+	public get isDisabled(): boolean {
 		return this.disabled || this.groupDisabled;
 	}
 
-	handleClick = (): void => {
+	public handleClick = (): void => {
 		if (this.isDisabled) return;
 		this.elementRef.dispatchEvent(
 			new CustomEvent('ml:item-click', {

--- a/packages/melodic-components/src/components/forms/button-group/button-group.component.ts
+++ b/packages/melodic-components/src/components/forms/button-group/button-group.component.ts
@@ -33,37 +33,37 @@ import { buttonGroupStyles } from './button-group.styles.js';
 	attributes: ['value', 'variant', 'size', 'disabled', 'multiple']
 })
 export class ButtonGroupComponent implements IElementRef, OnCreate, OnDestroy {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Currently selected value (single selection mode) */
-	value = '';
+	public value = '';
 
 	/** Active state style: 'outline' (gray) or 'solid' (primary color) */
-	variant: 'outline' | 'solid' = 'outline';
+	public variant: 'outline' | 'solid' = 'outline';
 
 	/** Size variant */
-	size: Size = 'md';
+	public size: Size = 'md';
 
 	/** Disable the entire group */
-	disabled = false;
+	public disabled = false;
 
 	/** Allow multiple selections */
-	multiple = false;
+	public multiple = false;
 
 	/** Selected values (multiple mode) */
-	values: string[] = [];
+	public values: string[] = [];
 
-	onCreate(): void {
+	public onCreate(): void {
 		this.elementRef.addEventListener('ml:item-click', this._handleItemClick as EventListener);
 		this.syncItems();
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this.elementRef.removeEventListener('ml:item-click', this._handleItemClick as EventListener);
 	}
 
 	/** Handle slot changes to sync initial state */
-	handleSlotChange = (): void => {
+	public handleSlotChange = (): void => {
 		this.syncItems();
 	};
 

--- a/packages/melodic-components/src/components/forms/button/button.component.ts
+++ b/packages/melodic-components/src/components/forms/button/button.component.ts
@@ -32,27 +32,27 @@ import { buttonStyles } from './button.styles.js';
 	attributes: ['variant', 'size', 'type', 'disabled', 'loading', 'full-width']
 })
 export class ButtonComponent implements IElementRef, OnInit {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Button variant style */
-	variant: ButtonVariant = 'primary';
+	public variant: ButtonVariant = 'primary';
 
 	/** Button size */
-	size: Size = 'md';
+	public size: Size = 'md';
 
 	/** HTML button type */
-	type: ButtonType = 'button';
+	public type: ButtonType = 'button';
 
 	/** Disable the button */
-	disabled = false;
+	public disabled = false;
 
 	/** Show loading state */
-	loading = false;
+	public loading = false;
 
 	/** Make button full width */
-	fullWidth = false;
+	public fullWidth = false;
 
-	onInit(): void {
+	public onInit(): void {
 		// Ensure proper ARIA role
 		if (!this.elementRef.hasAttribute('role')) {
 			this.elementRef.setAttribute('role', 'button');
@@ -60,12 +60,12 @@ export class ButtonComponent implements IElementRef, OnInit {
 	}
 
 	/** Whether the button is effectively disabled */
-	get isDisabled(): boolean {
+	public get isDisabled(): boolean {
 		return this.disabled || this.loading;
 	}
 
 	/** Handle click events */
-	handleClick = (event: MouseEvent): void => {
+	public handleClick = (event: MouseEvent): void => {
 		if (this.isDisabled) {
 			event.preventDefault();
 			event.stopPropagation();

--- a/packages/melodic-components/src/components/forms/checkbox/checkbox.component.ts
+++ b/packages/melodic-components/src/components/forms/checkbox/checkbox.component.ts
@@ -23,27 +23,27 @@ import { checkboxStyles } from './checkbox.styles.js';
 	attributes: ['label', 'hint', 'size', 'checked', 'indeterminate', 'disabled']
 })
 export class CheckboxComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Checkbox label */
-	label = '';
+	public label = '';
 
 	/** Hint text below the checkbox */
-	hint = '';
+	public hint = '';
 
 	/** Checkbox size */
-	size: Size = 'md';
+	public size: Size = 'md';
 
 	/** Checked state */
-	checked = false;
+	public checked = false;
 
 	/** Indeterminate state */
-	indeterminate = false;
+	public indeterminate = false;
 
 	/** Disabled state */
-	disabled = false;
+	public disabled = false;
 
-	handleChange = (event: Event): void => {
+	public handleChange = (event: Event): void => {
 		if (this.disabled) {
 			event.preventDefault();
 			return;

--- a/packages/melodic-components/src/components/forms/date-picker/calendar.component.ts
+++ b/packages/melodic-components/src/components/forms/date-picker/calendar.component.ts
@@ -45,28 +45,28 @@ function todayIso(): string {
 	attributes: ['value', 'min', 'max']
 })
 export class CalendarComponent implements IElementRef, OnInit, OnAttributeChange {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Selected date in ISO format (YYYY-MM-DD) */
-	value = '';
+	public value = '';
 
 	/** Minimum selectable date (YYYY-MM-DD) */
-	min = '';
+	public min = '';
 
 	/** Maximum selectable date (YYYY-MM-DD) */
-	max = '';
+	public max = '';
 
 	/** Currently viewed month (0-11) */
-	viewMonth = new Date().getMonth();
+	public viewMonth = new Date().getMonth();
 
 	/** Currently viewed year */
-	viewYear = new Date().getFullYear();
+	public viewYear = new Date().getFullYear();
 
-	onInit(): void {
+	public onInit(): void {
 		this.navigateToValue();
 	}
 
-	onAttributeChange(name: string, _: unknown, newVal: unknown): void {
+	public onAttributeChange(name: string, _: unknown, newVal: unknown): void {
 		if (name === 'value' && newVal) {
 			this.navigateToValue();
 		}
@@ -81,15 +81,15 @@ export class CalendarComponent implements IElementRef, OnInit, OnAttributeChange
 		}
 	}
 
-	get monthLabel(): string {
+	public get monthLabel(): string {
 		return `${MONTH_NAMES[this.viewMonth]} ${this.viewYear}`;
 	}
 
-	get weekdays(): string[] {
+	public get weekdays(): string[] {
 		return WEEKDAYS;
 	}
 
-	get days(): CalendarDay[] {
+	public get days(): CalendarDay[] {
 		const year = this.viewYear;
 		const month = this.viewMonth;
 		const firstDayOfWeek = new Date(year, month, 1).getDay();
@@ -156,15 +156,15 @@ export class CalendarComponent implements IElementRef, OnInit, OnAttributeChange
 		return result;
 	}
 
-	prevYear = (): void => {
+	public prevYear = (): void => {
 		this.viewYear--;
 	};
 
-	nextYear = (): void => {
+	public nextYear = (): void => {
 		this.viewYear++;
 	};
 
-	prevMonth = (): void => {
+	public prevMonth = (): void => {
 		if (this.viewMonth === 0) {
 			this.viewMonth = 11;
 			this.viewYear--;
@@ -173,7 +173,7 @@ export class CalendarComponent implements IElementRef, OnInit, OnAttributeChange
 		}
 	};
 
-	nextMonth = (): void => {
+	public nextMonth = (): void => {
 		if (this.viewMonth === 11) {
 			this.viewMonth = 0;
 			this.viewYear++;
@@ -182,7 +182,7 @@ export class CalendarComponent implements IElementRef, OnInit, OnAttributeChange
 		}
 	};
 
-	selectDay = (day: CalendarDay): void => {
+	public selectDay = (day: CalendarDay): void => {
 		if (day.isDisabled) return;
 		this.value = day.iso;
 		// Navigate to the selected day's month if it's not the current view
@@ -197,7 +197,7 @@ export class CalendarComponent implements IElementRef, OnInit, OnAttributeChange
 		);
 	};
 
-	goToToday = (): void => {
+	public goToToday = (): void => {
 		const now = new Date();
 		this.viewMonth = now.getMonth();
 		this.viewYear = now.getFullYear();

--- a/packages/melodic-components/src/components/forms/date-picker/date-picker.component.ts
+++ b/packages/melodic-components/src/components/forms/date-picker/date-picker.component.ts
@@ -34,55 +34,55 @@ function formatDisplay(iso: string): string {
 	attributes: ['value', 'placeholder', 'label', 'hint', 'error', 'size', 'disabled', 'required', 'min', 'max']
 })
 export class DatePickerComponent implements IElementRef, OnCreate, OnDestroy {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Selected date in ISO format (YYYY-MM-DD) */
-	value = '';
+	public value = '';
 
 	/** Placeholder text */
-	placeholder = 'Select date';
+	public placeholder = 'Select date';
 
 	/** Field label */
-	label = '';
+	public label = '';
 
 	/** Hint text */
-	hint = '';
+	public hint = '';
 
 	/** Error message */
-	error = '';
+	public error = '';
 
 	/** Input size */
-	size: 'sm' | 'md' | 'lg' = 'md';
+	public size: 'sm' | 'md' | 'lg' = 'md';
 
 	/** Disabled state */
-	disabled = false;
+	public disabled = false;
 
 	/** Required state */
-	required = false;
+	public required = false;
 
 	/** Minimum selectable date (YYYY-MM-DD) */
-	min = '';
+	public min = '';
 
 	/** Maximum selectable date (YYYY-MM-DD) */
-	max = '';
+	public max = '';
 
 	/** Whether the calendar popover is open */
-	isOpen = false;
+	public isOpen = false;
 
 	private _cleanupAutoUpdate: (() => void) | null = null;
 
-	get displayValue(): string {
+	public get displayValue(): string {
 		return formatDisplay(this.value);
 	}
 
-	onCreate(): void {
+	public onCreate(): void {
 		const popoverEl = this.getPopoverEl();
 		if (popoverEl) {
 			popoverEl.addEventListener('toggle', this._handleToggle);
 		}
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this._cleanupAutoUpdate?.();
 		const popoverEl = this.getPopoverEl();
 		if (popoverEl) {
@@ -90,7 +90,7 @@ export class DatePickerComponent implements IElementRef, OnCreate, OnDestroy {
 		}
 	}
 
-	toggleCalendar = (): void => {
+	public toggleCalendar = (): void => {
 		if (this.disabled) return;
 		const popoverEl = this.getPopoverEl();
 		if (popoverEl) {
@@ -99,14 +99,14 @@ export class DatePickerComponent implements IElementRef, OnCreate, OnDestroy {
 	};
 
 	/** Called when a day is clicked - selects immediately and closes */
-	handleDateSelect = (event: Event): void => {
+	public handleDateSelect = (event: Event): void => {
 		event.stopPropagation();
 		const detail = (event as CustomEvent).detail as { value: string };
 		this.commitValue(detail.value);
 		this.closePopover();
 	};
 
-	handleKeyDown = (event: KeyboardEvent): void => {
+	public handleKeyDown = (event: KeyboardEvent): void => {
 		if (event.key === 'Escape' && this.isOpen) {
 			event.preventDefault();
 			this.closePopover();

--- a/packages/melodic-components/src/components/forms/date-time-picker/date-time-picker.component.ts
+++ b/packages/melodic-components/src/components/forms/date-time-picker/date-time-picker.component.ts
@@ -59,72 +59,72 @@ function formatDateTimeDisplay(value: string, use12Hour: boolean): string {
 	attributes: ['value', 'placeholder', 'label', 'hint', 'error', 'size', 'disabled', 'required', 'min-date', 'max-date', 'min-time', 'max-time', 'step', 'twelve-hour']
 })
 export class DateTimePickerComponent implements IElementRef, OnCreate, OnDestroy {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Selected datetime in ISO format (YYYY-MM-DDTHH:mm) */
-	value = '';
+	public value = '';
 
 	/** Placeholder text */
-	placeholder = 'Select date and time';
+	public placeholder = 'Select date and time';
 
 	/** Field label */
-	label = '';
+	public label = '';
 
 	/** Hint text */
-	hint = '';
+	public hint = '';
 
 	/** Error message */
-	error = '';
+	public error = '';
 
 	/** Input size */
-	size: 'sm' | 'md' | 'lg' = 'md';
+	public size: 'sm' | 'md' | 'lg' = 'md';
 
 	/** Disabled state */
-	disabled = false;
+	public disabled = false;
 
 	/** Required state */
-	required = false;
+	public required = false;
 
 	/** Minimum selectable date (YYYY-MM-DD) */
-	minDate = '';
+	public minDate = '';
 
 	/** Maximum selectable date (YYYY-MM-DD) */
-	maxDate = '';
+	public maxDate = '';
 
 	/** Minimum selectable time (HH:mm) */
-	minTime = '';
+	public minTime = '';
 
 	/** Maximum selectable time (HH:mm) */
-	maxTime = '';
+	public maxTime = '';
 
 	/** Time step in minutes */
-	step = 15;
+	public step = 15;
 
 	/** Use 12-hour format (default: true) */
-	twelveHour = true;
+	public twelveHour = true;
 
 	/** Internal date portion */
-	dateValue = '';
+	public dateValue = '';
 
 	/** Internal time portion */
-	timeValue = '';
+	public timeValue = '';
 
 	private _listeners: Array<() => void> = [];
 
-	get use12Hour(): boolean {
+	public get use12Hour(): boolean {
 		return this.twelveHour;
 	}
 
-	get displayValue(): string {
+	public get displayValue(): string {
 		return formatDateTimeDisplay(this.value, this.use12Hour);
 	}
 
-	onCreate(): void {
+	public onCreate(): void {
 		this.syncFromValue();
 		this.attachChildListeners();
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		for (const cleanup of this._listeners) cleanup();
 		this._listeners = [];
 	}

--- a/packages/melodic-components/src/components/forms/file-upload/file-icon.component.ts
+++ b/packages/melodic-components/src/components/forms/file-upload/file-icon.component.ts
@@ -13,18 +13,18 @@ import { fileIconStyles } from './file-icon.styles.js';
 	attributes: ['extension', 'color', 'size']
 })
 export class FileIconComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
-	extension = '';
-	color: FileIconColor | '' = '';
-	size: Size = 'md';
+	public extension = '';
+	public color: FileIconColor | '' = '';
+	public size: Size = 'md';
 
-	get resolvedColor(): FileIconColor {
+	public get resolvedColor(): FileIconColor {
 		if (this.color) return this.color;
 		return this.extension ? getColorForExtension(this.extension) : 'gray';
 	}
 
-	get displayExtension(): string {
+	public get displayExtension(): string {
 		return this.extension.toUpperCase();
 	}
 }

--- a/packages/melodic-components/src/components/forms/file-upload/file-upload-item.component.ts
+++ b/packages/melodic-components/src/components/forms/file-upload/file-upload-item.component.ts
@@ -11,29 +11,29 @@ import { fileUploadItemStyles } from './file-upload-item.styles.js';
 	attributes: ['name', 'size', 'status', 'progress', 'error']
 })
 export class FileUploadItemComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
-	name = '';
-	size = '';
-	status: FileUploadStatus = 'idle';
-	progress = 0;
-	error = '';
-	file: File | null = null;
+	public name = '';
+	public size = '';
+	public status: FileUploadStatus = 'idle';
+	public progress = 0;
+	public error = '';
+	public file: File | null = null;
 
-	get extension(): string {
+	public get extension(): string {
 		const parts = this.name.split('.');
 		return parts.length > 1 ? parts.pop()! : '';
 	}
 
-	get displayProgress(): string {
+	public get displayProgress(): string {
 		return `${Math.round(Math.min(Math.max(this.progress, 0), 100))}%`;
 	}
 
-	get progressWidth(): number {
+	public get progressWidth(): number {
 		return Math.min(Math.max(this.progress, 0), 100);
 	}
 
-	handleRemove = (): void => {
+	public handleRemove = (): void => {
 		this.elementRef.dispatchEvent(
 			new CustomEvent('ml:remove', {
 				bubbles: true,
@@ -43,7 +43,7 @@ export class FileUploadItemComponent implements IElementRef {
 		);
 	};
 
-	handleRetry = (): void => {
+	public handleRetry = (): void => {
 		this.elementRef.dispatchEvent(
 			new CustomEvent('ml:retry', {
 				bubbles: true,

--- a/packages/melodic-components/src/components/forms/file-upload/file-upload.component.ts
+++ b/packages/melodic-components/src/components/forms/file-upload/file-upload.component.ts
@@ -11,36 +11,36 @@ import { fileUploadStyles } from './file-upload.styles.js';
 	attributes: ['accept', 'multiple', 'max-size', 'max-files', 'disabled', 'label', 'sublabel', 'hint', 'error', 'icon']
 })
 export class FileUploadComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
-	accept = '';
-	multiple = false;
-	maxSize = 0;
-	maxFiles = 0;
-	disabled = false;
-	label = 'Click to upload';
-	sublabel = 'or drag and drop';
-	hint = '';
-	error = '';
-	icon = 'cloud-arrow-up';
+	public accept = '';
+	public multiple = false;
+	public maxSize = 0;
+	public maxFiles = 0;
+	public disabled = false;
+	public label = 'Click to upload';
+	public sublabel = 'or drag and drop';
+	public hint = '';
+	public error = '';
+	public icon = 'cloud-arrow-up';
 
-	dragOver = false;
-	_dragCounter = 0;
+	public dragOver = false;
+	private _dragCounter = 0;
 
-	handleClick = (): void => {
+	public handleClick = (): void => {
 		if (this.disabled) return;
 		const input = this.elementRef.shadowRoot?.querySelector('input[type="file"]') as HTMLInputElement;
 		input?.click();
 	};
 
-	handleFileInput = (event: Event): void => {
+	public handleFileInput = (event: Event): void => {
 		const input = event.target as HTMLInputElement;
 		if (!input.files?.length) return;
 		this.processFiles(Array.from(input.files));
 		input.value = '';
 	};
 
-	handleDragEnter = (event: DragEvent): void => {
+	public handleDragEnter = (event: DragEvent): void => {
 		event.preventDefault();
 		event.stopPropagation();
 		if (this.disabled) return;
@@ -50,12 +50,12 @@ export class FileUploadComponent implements IElementRef {
 		}
 	};
 
-	handleDragOver = (event: DragEvent): void => {
+	public handleDragOver = (event: DragEvent): void => {
 		event.preventDefault();
 		event.stopPropagation();
 	};
 
-	handleDragLeave = (event: DragEvent): void => {
+	public handleDragLeave = (event: DragEvent): void => {
 		event.preventDefault();
 		event.stopPropagation();
 		this._dragCounter--;
@@ -64,7 +64,7 @@ export class FileUploadComponent implements IElementRef {
 		}
 	};
 
-	handleDrop = (event: DragEvent): void => {
+	public handleDrop = (event: DragEvent): void => {
 		event.preventDefault();
 		event.stopPropagation();
 		this._dragCounter = 0;
@@ -75,7 +75,7 @@ export class FileUploadComponent implements IElementRef {
 		this.processFiles(Array.from(files));
 	};
 
-	processFiles(files: File[]): void {
+	public processFiles(files: File[]): void {
 		const errors: FileValidationError[] = [];
 		let validFiles = files;
 

--- a/packages/melodic-components/src/components/forms/form-field/form-field.component.ts
+++ b/packages/melodic-components/src/components/forms/form-field/form-field.component.ts
@@ -32,55 +32,55 @@ import { formFieldStyles } from './form-field.styles.js';
 	attributes: ['label', 'hint', 'error', 'size', 'orientation', 'disabled', 'required']
 })
 export class FormFieldComponent implements IElementRef, OnCreate {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Label text */
-	label = '';
+	public label = '';
 
 	/** Hint text shown below the control */
-	hint = '';
+	public hint = '';
 
 	/** Error message (shows error state when set) */
-	error = '';
+	public error = '';
 
 	/** Field size */
-	size: Size = 'md';
+	public size: Size = 'md';
 
 	/** Layout orientation */
-	orientation: FormFieldOrientation = 'vertical';
+	public orientation: FormFieldOrientation = 'vertical';
 
 	/** Disabled state */
-	disabled = false;
+	public disabled = false;
 
 	/** Required field indicator */
-	required = false;
+	public required = false;
 
 	/** Unique ID for connecting label to control */
 	private readonly _fieldId = `ml-form-field-${Math.random().toString(36).slice(2, 9)}`;
 
-	get fieldId(): string {
+	public get fieldId(): string {
 		return this._fieldId;
 	}
 
-	get hintId(): string {
+	public get hintId(): string {
 		return `${this._fieldId}-hint`;
 	}
 
-	get errorId(): string {
+	public get errorId(): string {
 		return `${this._fieldId}-error`;
 	}
 
-	get describedBy(): string {
+	public get describedBy(): string {
 		if (this.error) return this.errorId;
 		if (this.hint) return this.hintId;
 		return '';
 	}
 
-	onCreate(): void {
+	public onCreate(): void {
 		this.connectSlottedControl();
 	}
 
-	handleSlotChange = (): void => {
+	public handleSlotChange = (): void => {
 		this.connectSlottedControl();
 	};
 

--- a/packages/melodic-components/src/components/forms/input/input.component.ts
+++ b/packages/melodic-components/src/components/forms/input/input.component.ts
@@ -31,52 +31,52 @@ import { inputStyles } from './input.styles.js';
 	attributes: ['type', 'value', 'placeholder', 'label', 'hint', 'error', 'size', 'disabled', 'readonly', 'required', 'autocomplete']
 })
 export class InputComponent implements IElementRef, OnInit {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Input type */
-	type: InputType = 'text';
+	public type: InputType = 'text';
 
 	/** Current value */
-	value = '';
+	public value = '';
 
 	/** Placeholder text */
-	placeholder = '';
+	public placeholder = '';
 
 	/** Label text */
-	label = '';
+	public label = '';
 
 	/** Hint text shown below input */
-	hint = '';
+	public hint = '';
 
 	/** Error message (shows error state when set) */
-	error = '';
+	public error = '';
 
 	/** Input size */
-	size: Size = 'md';
+	public size: Size = 'md';
 
 	/** Disable the input */
-	disabled = false;
+	public disabled = false;
 
 	/** Make input readonly */
-	readonly = false;
+	public readonly = false;
 
 	/** Mark as required */
-	required = false;
+	public required = false;
 
 	/** Autocomplete attribute */
-	autocomplete = 'off';
+	public autocomplete = 'off';
 
 	/** Internal focus state */
-	focused = false;
+	public focused = false;
 
-	onInit(): void {
+	public onInit(): void {
 		// Set up aria-label if no label provided
 		if (!this.label && this.placeholder) {
 			this.elementRef.setAttribute('aria-label', this.placeholder);
 		}
 	}
 
-	handleInput = (event: Event): void => {
+	public handleInput = (event: Event): void => {
 		const target = event.target as HTMLInputElement;
 		this.value = target.value;
 
@@ -89,7 +89,7 @@ export class InputComponent implements IElementRef, OnInit {
 		);
 	};
 
-	handleChange = (event: Event): void => {
+	public handleChange = (event: Event): void => {
 		const target = event.target as HTMLInputElement;
 		this.value = target.value;
 
@@ -102,7 +102,7 @@ export class InputComponent implements IElementRef, OnInit {
 		);
 	};
 
-	handleFocus = (): void => {
+	public handleFocus = (): void => {
 		this.focused = true;
 		this.elementRef.dispatchEvent(
 			new CustomEvent('ml:focus', {
@@ -112,7 +112,7 @@ export class InputComponent implements IElementRef, OnInit {
 		);
 	};
 
-	handleBlur = (): void => {
+	public handleBlur = (): void => {
 		this.focused = false;
 		this.elementRef.dispatchEvent(
 			new CustomEvent('ml:blur', {

--- a/packages/melodic-components/src/components/forms/radio-card-group/radio-card-group.component.ts
+++ b/packages/melodic-components/src/components/forms/radio-card-group/radio-card-group.component.ts
@@ -23,39 +23,39 @@ import { radioCardGroupStyles } from './radio-card-group.styles.js';
 	attributes: ['value', 'label', 'hint', 'error', 'orientation', 'disabled', 'required']
 })
 export class RadioCardGroupComponent implements IElementRef, OnCreate, OnDestroy {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Currently selected value */
-	value = '';
+	public value = '';
 
 	/** Group label */
-	label = '';
+	public label = '';
 
 	/** Hint text */
-	hint = '';
+	public hint = '';
 
 	/** Error message */
-	error = '';
+	public error = '';
 
 	/** Layout orientation */
-	orientation: 'vertical' | 'horizontal' = 'vertical';
+	public orientation: 'vertical' | 'horizontal' = 'vertical';
 
 	/** Disabled state */
-	disabled = false;
+	public disabled = false;
 
 	/** Required state */
-	required = false;
+	public required = false;
 
-	onCreate(): void {
+	public onCreate(): void {
 		this.elementRef.addEventListener('ml:card-select', this._handleCardSelect as EventListener);
 		this.syncCards();
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this.elementRef.removeEventListener('ml:card-select', this._handleCardSelect as EventListener);
 	}
 
-	handleSlotChange = (): void => {
+	public handleSlotChange = (): void => {
 		this.syncCards();
 	};
 

--- a/packages/melodic-components/src/components/forms/radio-card-group/radio-card.component.ts
+++ b/packages/melodic-components/src/components/forms/radio-card-group/radio-card.component.ts
@@ -20,37 +20,37 @@ import { radioCardStyles } from './radio-card.styles.js';
 	attributes: ['value', 'label', 'description', 'detail', 'icon', 'selected', 'disabled', 'group-disabled']
 })
 export class RadioCardComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Card value identifier */
-	value = '';
+	public value = '';
 
 	/** Primary label */
-	label = '';
+	public label = '';
 
 	/** Description text below label */
-	description = '';
+	public description = '';
 
 	/** Secondary detail text (e.g. price), shown on the right */
-	detail = '';
+	public detail = '';
 
 	/** Optional icon name */
-	icon = '';
+	public icon = '';
 
 	/** Selected state (managed by parent via attribute) */
-	selected = false;
+	public selected = false;
 
 	/** Disabled state on this card */
-	disabled = false;
+	public disabled = false;
 
 	/** Disabled state from parent group */
-	groupDisabled = false;
+	public groupDisabled = false;
 
-	get isDisabled(): boolean {
+	public get isDisabled(): boolean {
 		return this.disabled || this.groupDisabled;
 	}
 
-	handleClick = (): void => {
+	public handleClick = (): void => {
 		if (this.isDisabled) return;
 		this.elementRef.dispatchEvent(
 			new CustomEvent('ml:card-select', {

--- a/packages/melodic-components/src/components/forms/radio/radio-group.component.ts
+++ b/packages/melodic-components/src/components/forms/radio/radio-group.component.ts
@@ -24,33 +24,33 @@ import { radioGroupStyles } from './radio-group.styles.js';
 	attributes: ['label', 'name', 'value', 'hint', 'error', 'orientation', 'disabled', 'required']
 })
 export class RadioGroupComponent implements IElementRef, OnInit {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Group label */
-	label = '';
+	public label = '';
 
 	/** Form field name */
-	name = '';
+	public name = '';
 
 	/** Current selected value */
-	value = '';
+	public value = '';
 
 	/** Hint text */
-	hint = '';
+	public hint = '';
 
 	/** Error message */
-	error = '';
+	public error = '';
 
 	/** Layout orientation */
-	orientation: Orientation = 'vertical';
+	public orientation: Orientation = 'vertical';
 
 	/** Disabled state */
-	disabled = false;
+	public disabled = false;
 
 	/** Required state */
-	required = false;
+	public required = false;
 
-	onInit(): void {
+	public onInit(): void {
 		// Listen for changes from child radios
 		this.elementRef.addEventListener('ml:change', this.handleChildChange as EventListener);
 

--- a/packages/melodic-components/src/components/forms/radio/radio.component.ts
+++ b/packages/melodic-components/src/components/forms/radio/radio.component.ts
@@ -22,30 +22,30 @@ import { radioStyles } from './radio.styles.js';
 	attributes: ['name', 'value', 'label', 'hint', 'size', 'checked', 'disabled']
 })
 export class RadioComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Radio group name */
-	name = '';
+	public name = '';
 
 	/** Radio value */
-	value = '';
+	public value = '';
 
 	/** Radio label */
-	label = '';
+	public label = '';
 
 	/** Hint text */
-	hint = '';
+	public hint = '';
 
 	/** Radio size */
-	size: Size = 'md';
+	public size: Size = 'md';
 
 	/** Checked state */
-	checked = false;
+	public checked = false;
 
 	/** Disabled state */
-	disabled = false;
+	public disabled = false;
 
-	handleChange = (): void => {
+	public handleChange = (): void => {
 		this.checked = true;
 
 		this.elementRef.dispatchEvent(

--- a/packages/melodic-components/src/components/forms/select/select.component.ts
+++ b/packages/melodic-components/src/components/forms/select/select.component.ts
@@ -45,49 +45,49 @@ import { selectStyles } from './select.styles.js';
 	attributes: ['label', 'placeholder', 'hint', 'error', 'size', 'disabled', 'required', 'value', 'multiple']
 })
 export class SelectComponent implements IElementRef, OnCreate, OnDestroy {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Label text */
-	label = '';
+	public label = '';
 
 	/** Placeholder text when no selection */
-	placeholder = 'Select an option';
+	public placeholder = 'Select an option';
 
 	/** Hint text shown below select */
-	hint = '';
+	public hint = '';
 
 	/** Error message (shows error state when set) */
-	error = '';
+	public error = '';
 
 	/** Select size */
-	size: Size = 'md';
+	public size: Size = 'md';
 
 	/** Disable the select */
-	disabled = false;
+	public disabled = false;
 
 	/** Mark as required */
-	required = false;
+	public required = false;
 
 	/** Enable multi-select mode */
-	multiple = false;
+	public multiple = false;
 
 	/** Currently selected value */
-	value = '';
+	public value = '';
 
 	/** Currently selected values (multi-select) */
-	values: string[] = [];
+	public values: string[] = [];
 
 	/** Available options */
-	options: SelectOption[] = [];
+	public options: SelectOption[] = [];
 
 	/** Search query for inline filtering */
-	search = '';
+	public search = '';
 
 	/** Whether dropdown is open */
-	isOpen = false;
+	public isOpen = false;
 
 	/** Currently focused option index for keyboard navigation */
-	focusedIndex = -1;
+	public focusedIndex = -1;
 
 	/** Bound event handlers for cleanup */
 	private readonly _handleKeyDown = this.onKeyDown.bind(this);
@@ -96,18 +96,18 @@ export class SelectComponent implements IElementRef, OnCreate, OnDestroy {
 	private _lastCloseTime = 0;
 	private _syncingValues = false;
 
-	onCreate(): void {
+	public onCreate(): void {
 		this.elementRef.addEventListener('keydown', this._handleKeyDown);
 		this.getDropdownEl()?.addEventListener('toggle', this._handlePopoverToggle);
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this.elementRef.removeEventListener('keydown', this._handleKeyDown);
 		this.removeScrollListener();
 		this.getDropdownEl()?.removeEventListener('toggle', this._handlePopoverToggle);
 	}
 
-	onPropertyChange(name: string): void {
+	public onPropertyChange(name: string): void {
 		if (this._syncingValues) {
 			return;
 		}
@@ -162,12 +162,12 @@ export class SelectComponent implements IElementRef, OnCreate, OnDestroy {
 	}
 
 	/** Get the currently selected option */
-	get selectedOption(): SelectOption | undefined {
+	public get selectedOption(): SelectOption | undefined {
 		return this.options.find((opt) => opt.value === this.value);
 	}
 
 	/** Get the currently selected options (multi-select) */
-	get selectedOptions(): SelectOption[] {
+	public get selectedOptions(): SelectOption[] {
 		if (!this.multiple) {
 			return this.selectedOption ? [this.selectedOption] : [];
 		}
@@ -176,7 +176,7 @@ export class SelectComponent implements IElementRef, OnCreate, OnDestroy {
 	}
 
 	/** Get display text for trigger */
-	get displayText(): string {
+	public get displayText(): string {
 		if (this.multiple) {
 			return this.selectedOptions.map((option) => option.label).join(', ');
 		}
@@ -184,7 +184,7 @@ export class SelectComponent implements IElementRef, OnCreate, OnDestroy {
 		return this.selectedOption?.label || '';
 	}
 
-	get filteredOptions(): SelectOption[] {
+	public get filteredOptions(): SelectOption[] {
 		const query = this.search.trim().toLowerCase();
 		if (!query) return this.options;
 
@@ -195,12 +195,12 @@ export class SelectComponent implements IElementRef, OnCreate, OnDestroy {
 		});
 	}
 
-	get hasValue(): boolean {
+	public get hasValue(): boolean {
 		return this.multiple ? this.values.length > 0 : !!this.value;
 	}
 
 	/** Toggle dropdown open/close */
-	toggle = (): void => {
+	public toggle = (): void => {
 		if (this.disabled) return;
 
 		if (this.multiple) {
@@ -218,19 +218,19 @@ export class SelectComponent implements IElementRef, OnCreate, OnDestroy {
 	};
 
 	/** Open the dropdown */
-	open = (): void => {
+	public open = (): void => {
 		if (this.disabled || this.isOpen) return;
 		this.getDropdownEl()?.showPopover();
 	};
 
 	/** Close the dropdown */
-	close = (): void => {
+	public close = (): void => {
 		if (!this.isOpen) return;
 		this.getDropdownEl()?.hidePopover();
 	};
 
 	/** Select an option */
-	selectOption = (option: SelectOption): void => {
+	public selectOption = (option: SelectOption): void => {
 		if (option.disabled) return;
 
 		if (this.multiple) {
@@ -265,12 +265,12 @@ export class SelectComponent implements IElementRef, OnCreate, OnDestroy {
 	}
 
 	/** Handle click on option */
-	handleOptionClick = (event: Event, option: SelectOption): void => {
+	public handleOptionClick = (event: Event, option: SelectOption): void => {
 		event.stopPropagation();
 		this.selectOption(option);
 	};
 
-	handleTagRemove = (event: Event, value: string): void => {
+	public handleTagRemove = (event: Event, value: string): void => {
 		event.stopPropagation();
 		if (this.disabled) return;
 
@@ -284,7 +284,7 @@ export class SelectComponent implements IElementRef, OnCreate, OnDestroy {
 		);
 	};
 
-	handleSearchInput = (event: Event): void => {
+	public handleSearchInput = (event: Event): void => {
 		if (this.disabled) return;
 		const target = event.target as HTMLInputElement;
 		this.search = target.value;
@@ -294,7 +294,7 @@ export class SelectComponent implements IElementRef, OnCreate, OnDestroy {
 		}
 	};
 
-	handleSearchClick = (event: Event): void => {
+	public handleSearchClick = (event: Event): void => {
 		event.stopPropagation();
 		if (!this.isOpen) {
 			this.open();

--- a/packages/melodic-components/src/components/forms/slider/slider.component.ts
+++ b/packages/melodic-components/src/components/forms/slider/slider.component.ts
@@ -23,52 +23,52 @@ import { sliderStyles } from './slider.styles.js';
 	attributes: ['label', 'value', 'min', 'max', 'step', 'size', 'disabled', 'show-value', 'hint', 'error']
 })
 export class SliderComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Label text */
-	label = '';
+	public label = '';
 
 	/** Current value */
-	value = 50;
+	public value = 50;
 
 	/** Minimum value */
-	min = 0;
+	public min = 0;
 
 	/** Maximum value */
-	max = 100;
+	public max = 100;
 
 	/** Step increment */
-	step = 1;
+	public step = 1;
 
 	/** Slider size */
-	size: Size = 'md';
+	public size: Size = 'md';
 
 	/** Disable the slider */
-	disabled = false;
+	public disabled = false;
 
 	/** Show current value */
-	showValue = false;
+	public showValue = false;
 
 	/** Hint text */
-	hint = '';
+	public hint = '';
 
 	/** Error message */
-	error = '';
+	public error = '';
 
 	/** Ratio 0–1 for fill track */
-	get ratio(): number {
+	public get ratio(): number {
 		const range = this.max - this.min;
 		if (range <= 0) return 0;
 		return (this.value - this.min) / range;
 	}
 
 	/** CSS width for fill that matches native thumb position */
-	get fillWidth(): string {
+	public get fillWidth(): string {
 		const p = this.ratio;
 		return `calc(${p * 100}% + ${10 - p * 20}px)`;
 	}
 
-	handleInput = (event: Event): void => {
+	public handleInput = (event: Event): void => {
 		const target = event.target as HTMLInputElement;
 		this.value = Number(target.value);
 
@@ -81,7 +81,7 @@ export class SliderComponent implements IElementRef {
 		);
 	};
 
-	handleChange = (event: Event): void => {
+	public handleChange = (event: Event): void => {
 		const target = event.target as HTMLInputElement;
 		this.value = Number(target.value);
 

--- a/packages/melodic-components/src/components/forms/textarea/textarea.component.ts
+++ b/packages/melodic-components/src/components/forms/textarea/textarea.component.ts
@@ -26,54 +26,54 @@ import { textareaStyles } from './textarea.styles.js';
 	attributes: ['value', 'placeholder', 'label', 'hint', 'error', 'size', 'rows', 'max-length', 'disabled', 'readonly', 'required', 'resize']
 })
 export class TextareaComponent implements IElementRef, OnInit {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Current value */
-	value = '';
+	public value = '';
 
 	/** Placeholder text */
-	placeholder = '';
+	public placeholder = '';
 
 	/** Label text */
-	label = '';
+	public label = '';
 
 	/** Hint text shown below textarea */
-	hint = '';
+	public hint = '';
 
 	/** Error message (shows error state when set) */
-	error = '';
+	public error = '';
 
 	/** Input size */
-	size: Size = 'md';
+	public size: Size = 'md';
 
 	/** Number of visible text lines */
-	rows = 3;
+	public rows = 3;
 
 	/** Maximum character length */
-	maxLength = 0;
+	public maxLength = 0;
 
 	/** Disable the textarea */
-	disabled = false;
+	public disabled = false;
 
 	/** Make textarea readonly */
-	readonly = false;
+	public readonly = false;
 
 	/** Mark as required */
-	required = false;
+	public required = false;
 
 	/** Allow vertical resize */
-	resize = false;
+	public resize = false;
 
 	/** Internal focus state */
-	focused = false;
+	public focused = false;
 
-	onInit(): void {
+	public onInit(): void {
 		if (!this.label && this.placeholder) {
 			this.elementRef.setAttribute('aria-label', this.placeholder);
 		}
 	}
 
-	handleInput = (event: Event): void => {
+	public handleInput = (event: Event): void => {
 		const target = event.target as HTMLTextAreaElement;
 		this.value = target.value;
 
@@ -86,7 +86,7 @@ export class TextareaComponent implements IElementRef, OnInit {
 		);
 	};
 
-	handleChange = (event: Event): void => {
+	public handleChange = (event: Event): void => {
 		const target = event.target as HTMLTextAreaElement;
 		this.value = target.value;
 
@@ -99,7 +99,7 @@ export class TextareaComponent implements IElementRef, OnInit {
 		);
 	};
 
-	handleFocus = (): void => {
+	public handleFocus = (): void => {
 		this.focused = true;
 		this.elementRef.dispatchEvent(
 			new CustomEvent('ml:focus', {
@@ -109,7 +109,7 @@ export class TextareaComponent implements IElementRef, OnInit {
 		);
 	};
 
-	handleBlur = (): void => {
+	public handleBlur = (): void => {
 		this.focused = false;
 		this.elementRef.dispatchEvent(
 			new CustomEvent('ml:blur', {

--- a/packages/melodic-components/src/components/forms/time-picker/time-picker.component.ts
+++ b/packages/melodic-components/src/components/forms/time-picker/time-picker.component.ts
@@ -48,74 +48,74 @@ function clamp(val: number, min: number, max: number): number {
 	attributes: ['value', 'placeholder', 'label', 'hint', 'error', 'size', 'disabled', 'required', 'min', 'max', 'step', 'twelve-hour']
 })
 export class TimePickerComponent implements IElementRef, OnCreate, OnDestroy {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Selected time in HH:mm or HH:mm:ss format */
-	value = '';
+	public value = '';
 
 	/** Placeholder text */
-	placeholder = 'Select time';
+	public placeholder = 'Select time';
 
 	/** Field label */
-	label = '';
+	public label = '';
 
 	/** Hint text */
-	hint = '';
+	public hint = '';
 
 	/** Error message */
-	error = '';
+	public error = '';
 
 	/** Input size */
-	size: 'sm' | 'md' | 'lg' = 'md';
+	public size: 'sm' | 'md' | 'lg' = 'md';
 
 	/** Disabled state */
-	disabled = false;
+	public disabled = false;
 
 	/** Required state */
-	required = false;
+	public required = false;
 
 	/** Minimum selectable time (HH:mm) */
-	min = '';
+	public min = '';
 
 	/** Maximum selectable time (HH:mm) */
-	max = '';
+	public max = '';
 
 	/** Step in minutes (default 15) for the preset list. Use 1 to show seconds spinner. */
-	step = 15;
+	public step = 15;
 
 	/** Use 12-hour format with AM/PM (default: true) */
-	twelveHour = true;
+	public twelveHour = true;
 
 	/** Whether the popover is open */
-	isOpen = false;
+	public isOpen = false;
 
 	/** Current editing hour */
-	editHour = 0;
+	public editHour = 0;
 
 	/** Current editing minute */
-	editMinute = 0;
+	public editMinute = 0;
 
 	/** Current editing second */
-	editSecond = 0;
+	public editSecond = 0;
 
 	/** AM or PM when in 12-hour mode */
-	editPeriod: 'AM' | 'PM' = 'AM';
+	public editPeriod: 'AM' | 'PM' = 'AM';
 
 	private _cleanupAutoUpdate: (() => void) | null = null;
 
-	get use12Hour(): boolean {
+	public get use12Hour(): boolean {
 		return this.twelveHour;
 	}
 
-	get showSeconds(): boolean {
+	public get showSeconds(): boolean {
 		return Number(this.step) === 1;
 	}
 
-	get displayValue(): string {
+	public get displayValue(): string {
 		return formatDisplay(this.value, this.use12Hour);
 	}
 
-	get displayHour(): string {
+	public get displayHour(): string {
 		if (this.use12Hour) {
 			let h = this.editHour;
 			if (h === 0) h = 12;
@@ -125,22 +125,22 @@ export class TimePickerComponent implements IElementRef, OnCreate, OnDestroy {
 		return pad(this.editHour);
 	}
 
-	get displayMinute(): string {
+	public get displayMinute(): string {
 		return pad(this.editMinute);
 	}
 
-	get displaySecond(): string {
+	public get displaySecond(): string {
 		return pad(this.editSecond);
 	}
 
-	onCreate(): void {
+	public onCreate(): void {
 		const popoverEl = this.getPopoverEl();
 		if (popoverEl) {
 			popoverEl.addEventListener('toggle', this._handleToggle);
 		}
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this._cleanupAutoUpdate?.();
 		const popoverEl = this.getPopoverEl();
 		if (popoverEl) {
@@ -148,7 +148,7 @@ export class TimePickerComponent implements IElementRef, OnCreate, OnDestroy {
 		}
 	}
 
-	togglePopover = (): void => {
+	public togglePopover = (): void => {
 		if (this.disabled) return;
 		const popoverEl = this.getPopoverEl();
 		if (popoverEl) {
@@ -156,7 +156,7 @@ export class TimePickerComponent implements IElementRef, OnCreate, OnDestroy {
 		}
 	};
 
-	incrementHour = (): void => {
+	public incrementHour = (): void => {
 		if (this.use12Hour) {
 			// Cycle within the current 12-hour half (AM: 0–11, PM: 12–23)
 			const base = this.editPeriod === 'AM' ? 0 : 12;
@@ -167,7 +167,7 @@ export class TimePickerComponent implements IElementRef, OnCreate, OnDestroy {
 		}
 	};
 
-	decrementHour = (): void => {
+	public decrementHour = (): void => {
 		if (this.use12Hour) {
 			const base = this.editPeriod === 'AM' ? 0 : 12;
 			const offset = (this.editHour - base - 1 + 12) % 12;
@@ -177,29 +177,29 @@ export class TimePickerComponent implements IElementRef, OnCreate, OnDestroy {
 		}
 	};
 
-	incrementMinute = (): void => {
+	public incrementMinute = (): void => {
 		this.editMinute = clamp(this.editMinute + 1, 0, 59);
 	};
 
-	decrementMinute = (): void => {
+	public decrementMinute = (): void => {
 		this.editMinute = clamp(this.editMinute - 1, 0, 59);
 	};
 
-	incrementSecond = (): void => {
+	public incrementSecond = (): void => {
 		this.editSecond = clamp(this.editSecond + 1, 0, 59);
 	};
 
-	decrementSecond = (): void => {
+	public decrementSecond = (): void => {
 		this.editSecond = clamp(this.editSecond - 1, 0, 59);
 	};
 
-	togglePeriod = (): void => {
+	public togglePeriod = (): void => {
 		this.editPeriod = this.editPeriod === 'AM' ? 'PM' : 'AM';
 		const h12 = this.editHour % 12 || 12;
 		this.editHour = this.to24Hour(h12, this.editPeriod);
 	};
 
-	confirmSelection = (): void => {
+	public confirmSelection = (): void => {
 		let timeStr = `${pad(this.editHour)}:${pad(this.editMinute)}`;
 		if (this.showSeconds) {
 			timeStr += `:${pad(this.editSecond)}`;
@@ -208,7 +208,7 @@ export class TimePickerComponent implements IElementRef, OnCreate, OnDestroy {
 		this.closePopover();
 	};
 
-	handleNowClick = (): void => {
+	public handleNowClick = (): void => {
 		const now = new Date();
 		this.editHour = now.getHours();
 		this.editMinute = now.getMinutes();
@@ -216,7 +216,7 @@ export class TimePickerComponent implements IElementRef, OnCreate, OnDestroy {
 		this.editPeriod = this.editHour >= 12 ? 'PM' : 'AM';
 	};
 
-	handleKeyDown = (event: KeyboardEvent): void => {
+	public handleKeyDown = (event: KeyboardEvent): void => {
 		if (event.key === 'Escape' && this.isOpen) {
 			event.preventDefault();
 			this.closePopover();
@@ -226,7 +226,7 @@ export class TimePickerComponent implements IElementRef, OnCreate, OnDestroy {
 		}
 	};
 
-	handleHourInput = (event: Event): void => {
+	public handleHourInput = (event: Event): void => {
 		const input = event.target as HTMLInputElement;
 		const digits = input.value.replace(/\D/g, '').slice(0, 2);
 		if (digits === '') { input.value = ''; return; }
@@ -241,7 +241,7 @@ export class TimePickerComponent implements IElementRef, OnCreate, OnDestroy {
 		}
 	};
 
-	handleMinuteInput = (event: Event): void => {
+	public handleMinuteInput = (event: Event): void => {
 		const input = event.target as HTMLInputElement;
 		const digits = input.value.replace(/\D/g, '').slice(0, 2);
 		if (digits === '') { input.value = ''; return; }
@@ -250,7 +250,7 @@ export class TimePickerComponent implements IElementRef, OnCreate, OnDestroy {
 		this.editMinute = n;
 	};
 
-	handleSecondInput = (event: Event): void => {
+	public handleSecondInput = (event: Event): void => {
 		const input = event.target as HTMLInputElement;
 		const digits = input.value.replace(/\D/g, '').slice(0, 2);
 		if (digits === '') { input.value = ''; return; }
@@ -259,26 +259,26 @@ export class TimePickerComponent implements IElementRef, OnCreate, OnDestroy {
 		this.editSecond = n;
 	};
 
-	handleHourBlur = (): void => {
+	public handleHourBlur = (): void => {
 		if (this.use12Hour) {
 			const h12 = this.editHour % 12 || 12;
 			this.editHour = this.to24Hour(h12, this.editPeriod);
 		}
 	};
 
-	handleMinuteBlur = (): void => {
+	public handleMinuteBlur = (): void => {
 		// Re-render to reformat with padding
 	};
 
-	handleSecondBlur = (): void => {
+	public handleSecondBlur = (): void => {
 		// Re-render to reformat with padding
 	};
 
-	handleInputFocus = (event: Event): void => {
+	public handleInputFocus = (event: Event): void => {
 		(event.target as HTMLInputElement).select();
 	};
 
-	handleSpinnerKeyDown = (event: KeyboardEvent): void => {
+	public handleSpinnerKeyDown = (event: KeyboardEvent): void => {
 		const target = event.target as HTMLInputElement;
 		if (event.key === 'ArrowUp') {
 			event.preventDefault();

--- a/packages/melodic-components/src/components/forms/toggle/toggle.component.ts
+++ b/packages/melodic-components/src/components/forms/toggle/toggle.component.ts
@@ -23,24 +23,24 @@ import { toggleStyles } from './toggle.styles.js';
 	attributes: ['label', 'hint', 'size', 'checked', 'disabled']
 })
 export class ToggleComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Toggle label */
-	label = '';
+	public label = '';
 
 	/** Hint text */
-	hint = '';
+	public hint = '';
 
 	/** Toggle size */
-	size: Size = 'md';
+	public size: Size = 'md';
 
 	/** Checked state */
-	checked = false;
+	public checked = false;
 
 	/** Disabled state */
-	disabled = false;
+	public disabled = false;
 
-	handleChange = (event: Event): void => {
+	public handleChange = (event: Event): void => {
 		if (this.disabled) {
 			event.preventDefault();
 			return;

--- a/packages/melodic-components/src/components/foundation/card/card.component.ts
+++ b/packages/melodic-components/src/components/foundation/card/card.component.ts
@@ -28,28 +28,28 @@ type CardVariant = 'default' | 'outlined' | 'elevated' | 'filled';
 	attributes: ['variant', 'hoverable', 'clickable']
 })
 export class CardComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Card visual style */
-	variant: CardVariant = 'default';
+	public variant: CardVariant = 'default';
 
 	/** Add hover effect */
-	hoverable = false;
+	public hoverable = false;
 
 	/** Make card clickable */
-	clickable = false;
+	public clickable = false;
 
 	/** Internal: check if header slot has content */
-	get hasHeader(): boolean {
+	public get hasHeader(): boolean {
 		return this.elementRef?.querySelector('[slot="header"]') !== null;
 	}
 
 	/** Internal: check if footer slot has content */
-	get hasFooter(): boolean {
+	public get hasFooter(): boolean {
 		return this.elementRef?.querySelector('[slot="footer"]') !== null;
 	}
 
-	handleClick = (event: MouseEvent): void => {
+	public handleClick = (event: MouseEvent): void => {
 		if (this.clickable) {
 			this.elementRef.dispatchEvent(
 				new CustomEvent('ml:click', {

--- a/packages/melodic-components/src/components/foundation/container/container.component.ts
+++ b/packages/melodic-components/src/components/foundation/container/container.component.ts
@@ -28,18 +28,18 @@ type ContainerSize = 'sm' | 'md' | 'lg' | 'xl' | 'full';
 	attributes: ['size', 'padding', 'centered']
 })
 export class ContainerComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Max-width preset */
-	size: ContainerSize = 'lg';
+	public size: ContainerSize = 'lg';
 
 	/** Horizontal padding (spacing scale: 1-12) */
-	padding: string = '4';
+	public padding: string = '4';
 
 	/** Center the container with auto margins */
-	centered = true;
+	public centered = true;
 
-	getStyles(): Record<string, string> {
+	public getStyles(): Record<string, string> {
 		const maxWidthMap: Record<ContainerSize, string> = {
 			sm: '640px',
 			md: '768px',

--- a/packages/melodic-components/src/components/foundation/divider/divider.component.ts
+++ b/packages/melodic-components/src/components/foundation/divider/divider.component.ts
@@ -23,13 +23,13 @@ import { dividerStyles } from './divider.styles.js';
 	attributes: ['orientation']
 })
 export class DividerComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Divider orientation */
-	orientation: Orientation = 'horizontal';
+	public orientation: Orientation = 'horizontal';
 
 	/** Check if there's label content */
-	get hasLabel(): boolean {
+	public get hasLabel(): boolean {
 		return this.elementRef?.textContent?.trim() !== '';
 	}
 }

--- a/packages/melodic-components/src/components/foundation/stack/stack.component.ts
+++ b/packages/melodic-components/src/components/foundation/stack/stack.component.ts
@@ -30,24 +30,24 @@ type Justify = 'start' | 'center' | 'end' | 'between' | 'around' | 'evenly';
 	attributes: ['direction', 'gap', 'align', 'justify', 'wrap']
 })
 export class StackComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Stack direction */
-	direction: Orientation = 'vertical';
+	public direction: Orientation = 'vertical';
 
 	/** Gap between items (uses spacing scale: 1-12) */
-	gap: string = '4';
+	public gap: string = '4';
 
 	/** Cross-axis alignment */
-	align: Alignment = 'stretch';
+	public align: Alignment = 'stretch';
 
 	/** Main-axis justification */
-	justify: Justify = 'start';
+	public justify: Justify = 'start';
 
 	/** Allow items to wrap */
-	wrap = false;
+	public wrap = false;
 
-	getStyles(): Record<string, string> {
+	public getStyles(): Record<string, string> {
 		const alignMap: Record<Alignment, string> = {
 			start: 'flex-start',
 			center: 'center',

--- a/packages/melodic-components/src/components/general/icon/icon.component.ts
+++ b/packages/melodic-components/src/components/general/icon/icon.component.ts
@@ -22,8 +22,8 @@ import { iconStyles } from './icon.styles.js';
 })
 export class IconComponent {
 	/** phosphor icon ligature */
-	icon: string = '';
+	public icon: string = '';
 
 	/** phosphor icon format */
-	format: 'bold' | 'fill' | 'light' | 'regular' | 'thin' = 'regular';
+	public format: 'bold' | 'fill' | 'light' | 'regular' | 'thin' = 'regular';
 }

--- a/packages/melodic-components/src/components/navigation/breadcrumb/breadcrumb-item.component.ts
+++ b/packages/melodic-components/src/components/navigation/breadcrumb/breadcrumb-item.component.ts
@@ -21,21 +21,21 @@ import { breadcrumbItemStyles } from './breadcrumb-item.styles.js';
 	attributes: ['href', 'icon', 'current', 'separator']
 })
 export class BreadcrumbItemComponent implements IElementRef, OnCreate {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Link URL (omit for current/non-clickable page) */
-	href = '';
+	public href = '';
 
 	/** Optional left icon */
-	icon = '';
+	public icon = '';
 
 	/** Marks as the current/active page */
-	current = false;
+	public current = false;
 
 	/** Separator type inherited from parent (set via CSS/attribute) */
-	separator: 'slash' | 'chevron' = 'chevron';
+	public separator: 'slash' | 'chevron' = 'chevron';
 
-	onCreate(): void {
+	public onCreate(): void {
 		const parent = this.elementRef.closest('ml-breadcrumb');
 		if (parent) {
 			const sep = parent.getAttribute('separator');

--- a/packages/melodic-components/src/components/navigation/breadcrumb/breadcrumb.component.ts
+++ b/packages/melodic-components/src/components/navigation/breadcrumb/breadcrumb.component.ts
@@ -26,8 +26,8 @@ type BreadcrumbSeparator = 'slash' | 'chevron';
 	attributes: ['separator']
 })
 export class BreadcrumbComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Separator style between items */
-	separator: BreadcrumbSeparator = 'chevron';
+	public separator: BreadcrumbSeparator = 'chevron';
 }

--- a/packages/melodic-components/src/components/navigation/pagination/pagination.component.ts
+++ b/packages/melodic-components/src/components/navigation/pagination/pagination.component.ts
@@ -23,18 +23,18 @@ export type PaginationPage = { type: 'page'; value: number } | { type: 'ellipsis
 	attributes: ['page', 'total-pages', 'siblings']
 })
 export class PaginationComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Current active page (1-based) */
-	page = 1;
+	public page = 1;
 
 	/** Total number of pages */
-	totalPages = 1;
+	public totalPages = 1;
 
 	/** Number of sibling pages to show around current */
-	siblings = 1;
+	public siblings = 1;
 
-	get pages(): PaginationPage[] {
+	public get pages(): PaginationPage[] {
 		const total = Math.max(1, Number(this.totalPages));
 		const current = Math.min(Math.max(1, Number(this.page)), total);
 		const siblings = Math.max(0, Number(this.siblings));
@@ -71,15 +71,15 @@ export class PaginationComponent implements IElementRef {
 		];
 	}
 
-	get hasPrevious(): boolean {
+	public get hasPrevious(): boolean {
 		return Number(this.page) > 1;
 	}
 
-	get hasNext(): boolean {
+	public get hasNext(): boolean {
 		return Number(this.page) < Number(this.totalPages);
 	}
 
-	goToPage = (page: number): void => {
+	public goToPage = (page: number): void => {
 		const currentPage = Number(this.page);
 		const total = Number(this.totalPages);
 		if (page < 1 || page > total || page === currentPage) return;
@@ -94,11 +94,11 @@ export class PaginationComponent implements IElementRef {
 		);
 	};
 
-	previous = (): void => {
+	public previous = (): void => {
 		this.goToPage(Number(this.page) - 1);
 	};
 
-	next = (): void => {
+	public next = (): void => {
 		this.goToPage(Number(this.page) + 1);
 	};
 }

--- a/packages/melodic-components/src/components/navigation/sidebar/sidebar-group.component.ts
+++ b/packages/melodic-components/src/components/navigation/sidebar/sidebar-group.component.ts
@@ -23,11 +23,11 @@ import { sidebarGroupStyles } from './sidebar-group.styles.js';
 	attributes: ['label', 'collapsed']
 })
 export class SidebarGroupComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Group heading label */
-	label = '';
+	public label = '';
 
 	/** Collapsed state (set by parent sidebar) */
-	collapsed = false;
+	public collapsed = false;
 }

--- a/packages/melodic-components/src/components/navigation/sidebar/sidebar-item.component.ts
+++ b/packages/melodic-components/src/components/navigation/sidebar/sidebar-item.component.ts
@@ -29,70 +29,70 @@ import { sidebarItemStyles } from './sidebar-item.styles.js';
 	attributes: ['icon', 'label', 'value', 'href', 'active', 'disabled', 'badge', 'badge-color', 'external', 'expanded', 'collapsed', 'level']
 })
 export class SidebarItemComponent implements IElementRef, OnCreate, OnDestroy {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Icon name */
-	icon = '';
+	public icon = '';
 
 	/** Display label */
-	label = '';
+	public label = '';
 
 	/** Unique value identifier */
-	value = '';
+	public value = '';
 
 	/** Navigation URL */
-	href = '';
+	public href = '';
 
 	/** Active state (managed by parent sidebar) */
-	active = false;
+	public active = false;
 
 	/** Disabled state */
-	disabled = false;
+	public disabled = false;
 
 	/** Badge text */
-	badge = '';
+	public badge = '';
 
 	/** Badge color variant */
-	'badge-color': BadgeColor = 'default';
+	public 'badge-color': BadgeColor = 'default';
 
 	/** External link */
-	external = false;
+	public external = false;
 
 	/** Submenu expanded state */
-	expanded = false;
+	public expanded = false;
 
 	/** Collapsed state (set by parent sidebar in slim mode) */
-	collapsed = false;
+	public collapsed = false;
 
 	/** Indentation level for nested items */
-	level = '0';
+	public level = '0';
 
 	/** Track slotted children */
-	_hasChildren = false;
+	private _hasChildren = false;
 
 	/** Check if default slot has children */
-	get hasChildren(): boolean {
+	public get hasChildren(): boolean {
 		return this._hasChildren;
 	}
 
-	onCreate(): void {
+	public onCreate(): void {
 		// Check for slotted children
 		this._hasChildren = this.elementRef.querySelector('ml-sidebar-item') !== null;
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		// cleanup if needed
 	}
 
 	/** Handle default slot change to detect children */
-	handleSlotChange = (event: Event): void => {
+	public handleSlotChange = (event: Event): void => {
 		const slot = event.target as HTMLSlotElement;
 		const assigned = slot.assignedElements({ flatten: true });
 		this._hasChildren = assigned.some((el) => el.tagName === 'ML-SIDEBAR-ITEM');
 	};
 
 	/** Handle click on item */
-	handleClick = (event: Event): void => {
+	public handleClick = (event: Event): void => {
 		if (this.disabled) return;
 
 		if (this.hasChildren) {

--- a/packages/melodic-components/src/components/navigation/sidebar/sidebar.component.ts
+++ b/packages/melodic-components/src/components/navigation/sidebar/sidebar.component.ts
@@ -39,25 +39,22 @@ import { sidebarStyles } from './sidebar.styles.js';
 	attributes: ['variant', 'active']
 })
 export class SidebarComponent implements IElementRef, OnCreate, OnDestroy, OnRender {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Visual variant */
-	variant: SidebarVariant = 'default';
+	public variant: SidebarVariant = 'default';
 
 	/** Currently active item value */
-	active = '';
+	public active = '';
 
 	/** Collapsed state (controlled by slim variant hover) */
-	collapsed = false;
+	public collapsed = false;
 
 	/** Navigation config (alternative to slotted content) */
-	navigation: SidebarNavGroup[] = [];
+	public navigation: SidebarNavGroup[] = [];
 
 	/** Footer navigation config */
-	footerNavigation: SidebarNavItem[] = [];
-
-	/** Internal tracking of slotted items */
-	_slottedItems: HTMLElement[] = [];
+	public footerNavigation: SidebarNavItem[] = [];
 
 	/** Debounce timer for hover */
 	private _hoverTimer: ReturnType<typeof setTimeout> | null = null;
@@ -68,21 +65,21 @@ export class SidebarComponent implements IElementRef, OnCreate, OnDestroy, OnRen
 	private readonly _handleMouseLeave = this.onMouseLeave.bind(this);
 
 	/** Check if search slot has content */
-	get hasSearch(): boolean {
+	public get hasSearch(): boolean {
 		return this.elementRef?.querySelector('[slot="search"]') !== null;
 	}
 
 	/** Check if feature slot has content */
-	get hasFeature(): boolean {
+	public get hasFeature(): boolean {
 		return this.elementRef?.querySelector('[slot="feature"]') !== null;
 	}
 
 	/** Check if user slot has content */
-	get hasUser(): boolean {
+	public get hasUser(): boolean {
 		return this.elementRef?.querySelector('[slot="user"]') !== null;
 	}
 
-	onCreate(): void {
+	public onCreate(): void {
 		// Set initial collapsed state based on variant
 		if (this.variant === 'slim') {
 			this.collapsed = true;
@@ -98,11 +95,11 @@ export class SidebarComponent implements IElementRef, OnCreate, OnDestroy, OnRen
 		}
 	}
 
-	onRender(): void {
+	public onRender(): void {
 		this.updateItemStates();
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this.elementRef.removeEventListener('ml:sidebar-item-click', this._handleItemClick as EventListener);
 		this.elementRef.removeEventListener('mouseenter', this._handleMouseEnter);
 		this.elementRef.removeEventListener('mouseleave', this._handleMouseLeave);
@@ -113,19 +110,17 @@ export class SidebarComponent implements IElementRef, OnCreate, OnDestroy, OnRen
 	}
 
 	/** Handle slotted items change */
-	handleDefaultSlotChange = (event: Event): void => {
-		const slot = event.target as HTMLSlotElement;
-		this._slottedItems = slot.assignedElements({ flatten: true }) as HTMLElement[];
+	public handleDefaultSlotChange = (): void => {
 		this.updateItemStates();
 	};
 
 	/** Handle config item click */
-	handleConfigItemClick = (value: string, href?: string): void => {
+	public handleConfigItemClick = (value: string, href?: string): void => {
 		this.activateItem(value, href);
 	};
 
 	/** Handle config submenu toggle */
-	handleConfigToggle = (item: SidebarNavItem): void => {
+	public handleConfigToggle = (item: SidebarNavItem): void => {
 		const next = new Set(this.expandedItems);
 		if (next.has(item.value)) {
 			next.delete(item.value);
@@ -136,7 +131,7 @@ export class SidebarComponent implements IElementRef, OnCreate, OnDestroy, OnRen
 	};
 
 	/** Keyboard navigation */
-	handleKeyDown = (event: KeyboardEvent): void => {
+	public handleKeyDown = (event: KeyboardEvent): void => {
 		const sidebar = this.elementRef.shadowRoot?.querySelector('.ml-sidebar__main');
 		if (!sidebar) return;
 
@@ -174,7 +169,7 @@ export class SidebarComponent implements IElementRef, OnCreate, OnDestroy, OnRen
 	};
 
 	/** Track expanded config items */
-	expandedItems = new Set<string>();
+	public expandedItems = new Set<string>();
 
 	/** Activate an item */
 	private activateItem(value: string, href?: string): void {

--- a/packages/melodic-components/src/components/navigation/steps/step-panel.component.ts
+++ b/packages/melodic-components/src/components/navigation/steps/step-panel.component.ts
@@ -21,8 +21,8 @@ import { stepPanelStyles } from './step-panel.styles.js';
 	attributes: ['value']
 })
 export class StepPanelComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Panel identifier (must match ml-step value) */
-	value = '';
+	public value = '';
 }

--- a/packages/melodic-components/src/components/navigation/steps/step.component.ts
+++ b/packages/melodic-components/src/components/navigation/steps/step.component.ts
@@ -22,55 +22,55 @@ import { stepStyles } from './step.styles.js';
 	attributes: ['value', 'label', 'description', 'icon', 'disabled', 'status', 'variant', 'connector', 'color', 'orientation', 'step-number', 'first', 'last', 'compact']
 })
 export class StepComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Step identifier */
-	value = '';
+	public value = '';
 
 	/** Step title */
-	label = '';
+	public label = '';
 
 	/** Secondary description text */
-	description = '';
+	public description = '';
 
 	/** Icon name (for icons variant) */
-	icon = '';
+	public icon = '';
 
 	/** URL for routed mode */
-	href = '';
+	public href = '';
 
 	/** Disable this step */
-	disabled = false;
+	public disabled = false;
 
 	/** Step status (managed by parent) */
-	status: StepStatus = 'upcoming';
+	public status: StepStatus = 'upcoming';
 
 	/** Visual variant (managed by parent) */
-	variant: StepsVariant = 'numbered';
+	public variant: StepsVariant = 'numbered';
 
 	/** Connector style (managed by parent) */
-	connector: StepsConnector = 'solid';
+	public connector: StepsConnector = 'solid';
 
 	/** Accent color (managed by parent) */
-	color: StepsColor = 'primary';
+	public color: StepsColor = 'primary';
 
 	/** Layout orientation (managed by parent) */
-	orientation: StepsOrientation = 'horizontal';
+	public orientation: StepsOrientation = 'horizontal';
 
 	/** Step number (managed by parent) */
-	'step-number' = '1';
+	public 'step-number' = '1';
 
 	/** First step flag (managed by parent) */
-	first = false;
+	public first = false;
 
 	/** Last step flag (managed by parent) */
-	last = false;
+	public last = false;
 
 	/** Compact/dots mode (managed by parent) */
-	compact = false;
+	public compact = false;
 
 	/** Handle click on step */
-	handleClick = (): void => {
+	public handleClick = (): void => {
 		if (this.disabled) return;
 
 		this.elementRef.dispatchEvent(

--- a/packages/melodic-components/src/components/navigation/steps/steps.component.ts
+++ b/packages/melodic-components/src/components/navigation/steps/steps.component.ts
@@ -37,39 +37,39 @@ import { stepsStyles } from './steps.styles.js';
 	attributes: ['active', 'variant', 'orientation', 'connector', 'color', 'compact', 'routed']
 })
 export class StepsComponent implements IElementRef, OnCreate, OnDestroy, OnRender {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Currently active step value */
-	active = '';
+	public active = '';
 
 	/** Visual variant */
-	variant: StepsVariant = 'numbered';
+	public variant: StepsVariant = 'numbered';
 
 	/** Layout orientation */
-	orientation: StepsOrientation = 'horizontal';
+	public orientation: StepsOrientation = 'horizontal';
 
 	/** Connector line style */
-	connector: StepsConnector = 'solid';
+	public connector: StepsConnector = 'solid';
 
 	/** Accent color */
-	color: StepsColor = 'primary';
+	public color: StepsColor = 'primary';
 
 	/** Compact dots mode */
-	compact = false;
+	public compact = false;
 
 	/** Enable router integration */
-	routed = false;
+	public routed = false;
 
 	/** Step configurations (alternative to slotted ml-step elements) */
-	steps: StepConfig[] = [];
+	public steps: StepConfig[] = [];
 
 	/** Internal tracking of slotted steps */
-	_slottedSteps: HTMLElement[] = [];
+	private _slottedSteps: HTMLElement[] = [];
 
 	/** Navigation event listener for routed mode */
 	private readonly _handleNavigation = this.onNavigation.bind(this);
 
-	onCreate(): void {
+	public onCreate(): void {
 		// Listen for step click events from slotted ml-step elements
 		this.elementRef.addEventListener('ml:step-click', this.handleSlottedStepClick as EventListener);
 
@@ -79,11 +79,11 @@ export class StepsComponent implements IElementRef, OnCreate, OnDestroy, OnRende
 		}
 	}
 
-	onRender(): void {
+	public onRender(): void {
 		this.updatePanelVisibility();
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this.elementRef.removeEventListener('ml:step-click', this.handleSlottedStepClick as EventListener);
 
 		if (this.routed) {
@@ -92,7 +92,7 @@ export class StepsComponent implements IElementRef, OnCreate, OnDestroy, OnRende
 	}
 
 	/** Handle step slot changes */
-	handleStepSlotChange = (event: Event): void => {
+	public handleStepSlotChange = (event: Event): void => {
 		const slot = event.target as HTMLSlotElement;
 		this._slottedSteps = slot.assignedElements({ flatten: true }) as HTMLElement[];
 
@@ -109,7 +109,7 @@ export class StepsComponent implements IElementRef, OnCreate, OnDestroy, OnRende
 	};
 
 	/** Handle step click (config mode) */
-	handleStepClick = (stepValue: string, href?: string): void => {
+	public handleStepClick = (stepValue: string, href?: string): void => {
 		const step = this.getStepByValue(stepValue);
 		if (step?.disabled) return;
 
@@ -138,7 +138,7 @@ export class StepsComponent implements IElementRef, OnCreate, OnDestroy, OnRende
 	};
 
 	/** Handle keyboard navigation */
-	handleKeyDown = (event: KeyboardEvent): void => {
+	public handleKeyDown = (event: KeyboardEvent): void => {
 		const allSteps = this.getAllSteps();
 		const enabledSteps = allSteps.filter((s) => !s.disabled);
 		const currentIndex = enabledSteps.findIndex((s) => s.value === this.active);
@@ -187,7 +187,7 @@ export class StepsComponent implements IElementRef, OnCreate, OnDestroy, OnRende
 	};
 
 	/** Get status for a step based on its position relative to active */
-	getStepStatus(stepValue: string): StepStatus {
+	public getStepStatus(stepValue: string): StepStatus {
 		const allSteps = this.getAllSteps();
 		const activeIndex = allSteps.findIndex((s) => s.value === this.active);
 		const stepIndex = allSteps.findIndex((s) => s.value === stepValue);
@@ -198,19 +198,19 @@ export class StepsComponent implements IElementRef, OnCreate, OnDestroy, OnRende
 	}
 
 	/** Get current step index (1-based, for compact label) */
-	getCurrentStepNumber(): number {
+	public getCurrentStepNumber(): number {
 		const allSteps = this.getAllSteps();
 		const index = allSteps.findIndex((s) => s.value === this.active);
 		return index + 1;
 	}
 
 	/** Get total step count */
-	getTotalSteps(): number {
+	public getTotalSteps(): number {
 		return this.getAllSteps().length;
 	}
 
 	/** Get all steps (from config or slotted) */
-	getAllSteps(): StepConfig[] {
+	public getAllSteps(): StepConfig[] {
 		if (this.steps.length > 0) {
 			return this.steps;
 		}

--- a/packages/melodic-components/src/components/navigation/tabs/tab-panel.component.ts
+++ b/packages/melodic-components/src/components/navigation/tabs/tab-panel.component.ts
@@ -23,8 +23,8 @@ import { tabPanelStyles } from './tab-panel.styles.js';
 	attributes: ['value']
 })
 export class TabPanelComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Panel identifier (must match ml-tab value) */
-	value = '';
+	public value = '';
 }

--- a/packages/melodic-components/src/components/navigation/tabs/tab.component.ts
+++ b/packages/melodic-components/src/components/navigation/tabs/tab.component.ts
@@ -22,28 +22,28 @@ import { tabStyles } from './tab.styles.js';
 	attributes: ['value', 'label', 'icon', 'disabled', 'active', 'href']
 })
 export class TabComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Tab identifier (must match ml-tab-panel value) */
-	value = '';
+	public value = '';
 
 	/** Tab label text */
-	label = '';
+	public label = '';
 
 	/** Optional icon name */
-	icon = '';
+	public icon = '';
 
 	/** Disable this tab */
-	disabled = false;
+	public disabled = false;
 
 	/** Active state (managed by parent ml-tabs) */
-	active = false;
+	public active = false;
 
 	/** URL for routed tabs */
-	href = '';
+	public href = '';
 
 	/** Handle click on tab */
-	handleClick = (): void => {
+	public handleClick = (): void => {
 		if (this.disabled) return;
 
 		// Dispatch event for parent ml-tabs to handle

--- a/packages/melodic-components/src/components/navigation/tabs/tabs.component.ts
+++ b/packages/melodic-components/src/components/navigation/tabs/tabs.component.ts
@@ -48,28 +48,28 @@ import { tabsStyles } from './tabs.styles.js';
 	attributes: ['value', 'variant', 'size', 'orientation', 'routed']
 })
 export class TabsComponent implements IElementRef, OnCreate, OnDestroy, OnRender {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Currently active tab value */
-	value = '';
+	public value = '';
 
 	/** Visual variant */
-	variant: TabsVariant = 'line';
+	public variant: TabsVariant = 'line';
 
 	/** Size variant */
-	size: Size = 'md';
+	public size: Size = 'md';
 
 	/** Tab orientation */
-	orientation: TabsOrientation = 'horizontal';
+	public orientation: TabsOrientation = 'horizontal';
 
 	/** Enable router integration */
-	routed = false;
+	public routed = false;
 
 	/** Tab configurations (alternative to slotted ml-tab elements) */
-	tabs: TabConfig[] = [];
+	public tabs: TabConfig[] = [];
 
 	/** Internal tracking of slotted tabs */
-	_slottedTabs: HTMLElement[] = [];
+	private _slottedTabs: HTMLElement[] = [];
 
 	/** Navigation event listener for routed mode */
 	private readonly _handleNavigation = this.onNavigation.bind(this);
@@ -80,7 +80,7 @@ export class TabsComponent implements IElementRef, OnCreate, OnDestroy, OnRender
 		this.handleTabClick(value, href);
 	};
 
-	onCreate(): void {
+	public onCreate(): void {
 		this.elementRef.addEventListener('ml:tab-click', this._handleTabClick);
 
 		if (this.routed) {
@@ -89,12 +89,12 @@ export class TabsComponent implements IElementRef, OnCreate, OnDestroy, OnRender
 		}
 	}
 
-	onRender(): void {
+	public onRender(): void {
 		// Ensure panels are correctly shown/hidden after each render
 		this.updatePanelVisibility();
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this.elementRef.removeEventListener('ml:tab-click', this._handleTabClick);
 
 		if (this.routed) {
@@ -103,7 +103,7 @@ export class TabsComponent implements IElementRef, OnCreate, OnDestroy, OnRender
 	}
 
 	/** Handle tab slot changes */
-	handleTabSlotChange = (event: Event): void => {
+	public handleTabSlotChange = (event: Event): void => {
 		const slot = event.target as HTMLSlotElement;
 		this._slottedTabs = slot.assignedElements({ flatten: true }) as HTMLElement[];
 
@@ -120,7 +120,7 @@ export class TabsComponent implements IElementRef, OnCreate, OnDestroy, OnRender
 	};
 
 	/** Handle tab click */
-	handleTabClick = (tabValue: string, href?: string): void => {
+	public handleTabClick = (tabValue: string, href?: string): void => {
 		const tab = this.getTabByValue(tabValue);
 		if (tab?.disabled) return;
 
@@ -143,7 +143,7 @@ export class TabsComponent implements IElementRef, OnCreate, OnDestroy, OnRender
 	};
 
 	/** Handle keyboard navigation */
-	handleKeyDown = (event: KeyboardEvent): void => {
+	public handleKeyDown = (event: KeyboardEvent): void => {
 		const allTabs = this.getAllTabs();
 		const enabledTabs = allTabs.filter((t) => !t.disabled);
 		const currentIndex = enabledTabs.findIndex((t) => t.value === this.value);
@@ -181,7 +181,7 @@ export class TabsComponent implements IElementRef, OnCreate, OnDestroy, OnRender
 	};
 
 	/** Get all tabs (from config or slotted) */
-	getAllTabs(): TabConfig[] {
+	public getAllTabs(): TabConfig[] {
 		if (this.tabs.length > 0) {
 			return this.tabs;
 		}

--- a/packages/melodic-components/src/components/overlays/dialog/dialog-ref.class.ts
+++ b/packages/melodic-components/src/components/overlays/dialog/dialog-ref.class.ts
@@ -17,19 +17,19 @@ export class DialogRef<TResult = unknown, TData = unknown> {
 		this._dialogEl.addEventListener('click', this._handleBackdropClick);
 	}
 
-	get dialogID(): UniqueID {
+	public get dialogID(): UniqueID {
 		return this._dialogID;
 	}
 
-	get data(): TData | undefined {
+	public get data(): TData | undefined {
 		return this._data;
 	}
 
-	get disableClose(): boolean {
+	public get disableClose(): boolean {
 		return this._disableClose;
 	}
 
-	applyConfig(config: IDialogConfig<TData>): this {
+	public applyConfig(config: IDialogConfig<TData>): this {
 		if (config.data !== undefined) {
 			this._data = config.data;
 		}
@@ -54,21 +54,21 @@ export class DialogRef<TResult = unknown, TData = unknown> {
 		return this;
 	}
 
-	open(): void {
+	public open(): void {
 		this._dialogEl.showModal();
 		this._afterOpenedCallback?.();
 	}
 
-	close(result?: TResult): void {
+	public close(result?: TResult): void {
 		this._dialogEl.close();
 		this._afterClosedCallback?.(result);
 	}
 
-	afterOpened(callback: () => void): void {
+	public afterOpened(callback: () => void): void {
 		this._afterOpenedCallback = callback;
 	}
 
-	afterClosed(callback: (result: TResult | undefined) => void): void {
+	public afterClosed(callback: (result: TResult | undefined) => void): void {
 		this._afterClosedCallback = callback;
 	}
 

--- a/packages/melodic-components/src/components/overlays/dialog/dialog.component.ts
+++ b/packages/melodic-components/src/components/overlays/dialog/dialog.component.ts
@@ -23,7 +23,7 @@ export class DialogComponent implements IElementRef, OnCreate, OnDestroy {
 	private _dialogRef!: DialogRef;
 	private _registered = false;
 
-	onCreate(): void {
+	public onCreate(): void {
 		this.registerDialog();
 	}
 
@@ -40,16 +40,16 @@ export class DialogComponent implements IElementRef, OnCreate, OnDestroy {
 		this._registered = true;
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this._dialogService.removeDialog(this._dialogID);
 	}
 
-	open(): void {
+	public open(): void {
 		this.registerDialog();
 		this._dialogRef.open();
 	}
 
-	close<T = unknown>(result?: T): void {
+	public close<T = unknown>(result?: T): void {
 		this._dialogRef.close(result);
 	}
 

--- a/packages/melodic-components/src/components/overlays/dialog/dialog.service.ts
+++ b/packages/melodic-components/src/components/overlays/dialog/dialog.service.ts
@@ -19,7 +19,7 @@ interface IDialogElements<T = unknown> {
 export class DialogService {
 	private readonly _dialogs = new Map<UniqueID, IDialogElements>();
 
-	addDialog(dialogID: UniqueID, dialogEl: HTMLDialogElement): DialogRef {
+	public addDialog(dialogID: UniqueID, dialogEl: HTMLDialogElement): DialogRef {
 		const dialogRef = new DialogRef(dialogID, dialogEl);
 		this._dialogs.set(dialogID, {
 			dialogRef,
@@ -34,13 +34,13 @@ export class DialogService {
 		return dialogRef;
 	}
 
-	removeDialog(dialogID: UniqueID): void {
+	public removeDialog(dialogID: UniqueID): void {
 		this._dialogs.delete(dialogID);
 	}
 
-	open<TResult = unknown, TData = unknown>(dialogComponent: new (...args: any[]) => any, config?: IDialogConfig<TData>): DialogRef<TResult, TData>;
-	open<TResult = unknown, TData = unknown>(dialogID: UniqueID): DialogRef<TResult, TData>;
-	open<TResult = unknown, TData = unknown>(dialogComponentOrID: UniqueID | (new (...args: any[]) => any), config?: IDialogConfig<TData>): DialogRef<TResult, TData> {
+	public open<TResult = unknown, TData = unknown>(dialogComponent: new (...args: any[]) => any, config?: IDialogConfig<TData>): DialogRef<TResult, TData>;
+	public open<TResult = unknown, TData = unknown>(dialogID: UniqueID): DialogRef<TResult, TData>;
+	public open<TResult = unknown, TData = unknown>(dialogComponentOrID: UniqueID | (new (...args: any[]) => any), config?: IDialogConfig<TData>): DialogRef<TResult, TData> {
 		let dialogID: UniqueID = dialogComponentOrID as UniqueID;
 		let dialogElements: IDialogElements = this._dialogs.get(dialogID)!;
 
@@ -66,7 +66,7 @@ export class DialogService {
 		return dialogElements.dialogRef as DialogRef<TResult, TData>;
 	}
 
-	close<T = unknown>(dialogID: UniqueID, result?: T): void {
+	public close<T = unknown>(dialogID: UniqueID, result?: T): void {
 		if (this._dialogs.has(dialogID)) {
 			const dialogElements: IDialogElements = this._dialogs.get(dialogID)!;
 			dialogElements.dialogRef.close(result);

--- a/packages/melodic-components/src/components/overlays/drawer/drawer.component.ts
+++ b/packages/melodic-components/src/components/overlays/drawer/drawer.component.ts
@@ -33,16 +33,16 @@ type DrawerSize = 'sm' | 'md' | 'lg' | 'xl';
 	attributes: ['side', 'size', 'show-close']
 })
 export class DrawerComponent implements IElementRef, OnCreate, OnDestroy {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Which side the drawer slides from */
-	side: DrawerSide = 'right';
+	public side: DrawerSide = 'right';
 
 	/** Width preset */
-	size: DrawerSize = 'md';
+	public size: DrawerSize = 'md';
 
 	/** Show close button in header */
-	showClose = true;
+	public showClose = true;
 
 	private _dialogEl!: HTMLDialogElement;
 	private _panelEl!: HTMLElement;
@@ -57,20 +57,20 @@ export class DrawerComponent implements IElementRef, OnCreate, OnDestroy {
 		}
 	}
 
-	onCreate(): void {
+	public onCreate(): void {
 		this._dialogEl = this.elementRef.shadowRoot?.querySelector('dialog') as HTMLDialogElement;
 		this._panelEl = this._dialogEl?.querySelector('.ml-drawer__panel') as HTMLElement;
 		this._dialogEl?.addEventListener('click', this.handleBackdropClick);
 		this._dialogEl?.addEventListener('cancel', this.handleDialogCancel);
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this._dialogEl?.removeEventListener('click', this.handleBackdropClick);
 		this._dialogEl?.removeEventListener('cancel', this.handleDialogCancel);
 	}
 
 	/** Open the drawer */
-	open(): void {
+	public open(): void {
 		if (this._dialogEl?.open) return;
 		this.cancelAnimations();
 		this._dialogEl.showModal();
@@ -92,7 +92,7 @@ export class DrawerComponent implements IElementRef, OnCreate, OnDestroy {
 	}
 
 	/** Close the drawer */
-	close = (): void => {
+	public close = (): void => {
 		if (!this._dialogEl?.open) return;
 		this.cancelAnimations();
 		const prop = this._positionProp;

--- a/packages/melodic-components/src/components/overlays/dropdown/dropdown-group.component.ts
+++ b/packages/melodic-components/src/components/overlays/dropdown/dropdown-group.component.ts
@@ -23,5 +23,5 @@ import { dropdownGroupStyles } from './dropdown-group.styles.js';
 })
 export class DropdownGroupComponent {
 	/** Optional uppercase muted header label */
-	label = '';
+	public label = '';
 }

--- a/packages/melodic-components/src/components/overlays/dropdown/dropdown-item.component.ts
+++ b/packages/melodic-components/src/components/overlays/dropdown/dropdown-item.component.ts
@@ -22,27 +22,27 @@ import { dropdownItemStyles } from './dropdown-item.styles.js';
 	attributes: ['value', 'icon', 'addon', 'disabled', 'destructive']
 })
 export class DropdownItemComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Selection value emitted on click */
-	value = '';
+	public value = '';
 
 	/** Left icon name (Phosphor) */
-	icon = '';
+	public icon = '';
 
 	/** Right addon text (e.g. keyboard shortcut) */
-	addon = '';
+	public addon = '';
 
 	/** Non-interactive state */
-	disabled = false;
+	public disabled = false;
 
 	/** Red/danger styling */
-	destructive = false;
+	public destructive = false;
 
 	/** Set by parent dropdown for keyboard navigation highlight */
-	focused = false;
+	public focused = false;
 
-	handleClick = (): void => {
+	public handleClick = (): void => {
 		if (this.disabled) return;
 
 		this.elementRef.dispatchEvent(

--- a/packages/melodic-components/src/components/overlays/dropdown/dropdown.component.ts
+++ b/packages/melodic-components/src/components/overlays/dropdown/dropdown.component.ts
@@ -31,24 +31,24 @@ import { dropdownStyles } from './dropdown.styles.js';
 	attributes: ['placement', 'offset', 'arrow']
 })
 export class DropdownComponent implements IElementRef, OnCreate, OnDestroy {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Menu placement relative to trigger */
-	placement: Placement = 'bottom-start';
+	public placement: Placement = 'bottom-start';
 
 	/** Gap between trigger and menu in px */
-	offset = 4;
+	public offset = 4;
 
 	/** Show arrow pointing to trigger */
-	arrow = false;
+	public arrow = false;
 
 	/** Current open state */
-	isOpen = false;
+	public isOpen = false;
 
 	private _focusedIndex = -1;
 	private _cleanupAutoUpdate: (() => void) | null = null;
 
-	onCreate(): void {
+	public onCreate(): void {
 		const menuEl = this.getMenuEl();
 		if (menuEl) {
 			menuEl.addEventListener('toggle', this.handleToggle);
@@ -58,7 +58,7 @@ export class DropdownComponent implements IElementRef, OnCreate, OnDestroy {
 		this.elementRef.addEventListener('keydown', this.handleKeyDown);
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this._cleanupAutoUpdate?.();
 		const menuEl = this.getMenuEl();
 		if (menuEl) {
@@ -69,7 +69,7 @@ export class DropdownComponent implements IElementRef, OnCreate, OnDestroy {
 	}
 
 	/** Open the menu */
-	open(): void {
+	public open(): void {
 		const menuEl = this.getMenuEl();
 		if (menuEl && !this.isOpen) {
 			menuEl.showPopover();
@@ -77,7 +77,7 @@ export class DropdownComponent implements IElementRef, OnCreate, OnDestroy {
 	}
 
 	/** Close the menu */
-	close(): void {
+	public close(): void {
 		const menuEl = this.getMenuEl();
 		if (menuEl && this.isOpen) {
 			menuEl.hidePopover();
@@ -85,7 +85,7 @@ export class DropdownComponent implements IElementRef, OnCreate, OnDestroy {
 	}
 
 	/** Toggle the menu */
-	toggle = (): void => {
+	public toggle = (): void => {
 		const menuEl = this.getMenuEl();
 		if (menuEl) {
 			menuEl.togglePopover();

--- a/packages/melodic-components/src/components/overlays/popover/popover.component.ts
+++ b/packages/melodic-components/src/components/overlays/popover/popover.component.ts
@@ -34,33 +34,33 @@ import { popoverStyles } from './popover.styles.js';
 	attributes: ['placement', 'offset', 'manual', 'arrow']
 })
 export class PopoverComponent implements IElementRef, OnCreate, OnDestroy {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Popover placement relative to trigger */
-	placement: Placement = 'bottom';
+	public placement: Placement = 'bottom';
 
 	/** Gap between trigger and popover in px */
-	offset = 8;
+	public offset = 8;
 
 	/** When true, uses popover="manual" (no light-dismiss) */
-	manual = false;
+	public manual = false;
 
 	/** When true, shows an arrow pointing to the trigger */
-	arrow = false;
+	public arrow = false;
 
 	/** Current open state */
-	isOpen = false;
+	public isOpen = false;
 
 	private _cleanupAutoUpdate: (() => void) | null = null;
 
-	onCreate(): void {
+	public onCreate(): void {
 		const popoverEl = this.getPopoverEl();
 		if (popoverEl) {
 			popoverEl.addEventListener('toggle', this.handleToggle);
 		}
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this._cleanupAutoUpdate?.();
 		const popoverEl = this.getPopoverEl();
 		if (popoverEl) {
@@ -69,7 +69,7 @@ export class PopoverComponent implements IElementRef, OnCreate, OnDestroy {
 	}
 
 	/** Open the popover */
-	open(): void {
+	public open(): void {
 		const popoverEl = this.getPopoverEl();
 		if (popoverEl && !this.isOpen) {
 			popoverEl.showPopover();
@@ -77,7 +77,7 @@ export class PopoverComponent implements IElementRef, OnCreate, OnDestroy {
 	}
 
 	/** Close the popover */
-	close(): void {
+	public close(): void {
 		const popoverEl = this.getPopoverEl();
 		if (popoverEl && this.isOpen) {
 			popoverEl.hidePopover();
@@ -85,7 +85,7 @@ export class PopoverComponent implements IElementRef, OnCreate, OnDestroy {
 	}
 
 	/** Toggle the popover */
-	toggle = (): void => {
+	public toggle = (): void => {
 		const popoverEl = this.getPopoverEl();
 		if (popoverEl) {
 			popoverEl.togglePopover();

--- a/packages/melodic-components/src/components/overlays/tooltip/tooltip.component.ts
+++ b/packages/melodic-components/src/components/overlays/tooltip/tooltip.component.ts
@@ -28,33 +28,33 @@ import { tooltipStyles } from './tooltip.styles.js';
 	attributes: ['content', 'placement', 'delay']
 })
 export class TooltipComponent implements IElementRef, OnInit, OnDestroy {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Tooltip content text */
-	content = '';
+	public content = '';
 
 	/** Tooltip placement */
-	placement: Placement = 'top';
+	public placement: Placement = 'top';
 
 	/** Delay before showing (ms) */
-	delay = 200;
+	public delay = 200;
 
 	/** Internal: visibility state */
-	isVisible = false;
+	public isVisible = false;
 
 	private _showTimeout: number | null = null;
 	private _hideTimeout: number | null = null;
 
-	onInit(): void {
+	public onInit(): void {
 		// Initial setup if needed
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		if (this._showTimeout) clearTimeout(this._showTimeout);
 		if (this._hideTimeout) clearTimeout(this._hideTimeout);
 	}
 
-	show = (): void => {
+	public show = (): void => {
 		if (this._hideTimeout) {
 			clearTimeout(this._hideTimeout);
 			this._hideTimeout = null;
@@ -66,7 +66,7 @@ export class TooltipComponent implements IElementRef, OnInit, OnDestroy {
 		}, this.delay);
 	};
 
-	hide = (): void => {
+	public hide = (): void => {
 		if (this._showTimeout) {
 			clearTimeout(this._showTimeout);
 			this._showTimeout = null;

--- a/packages/melodic-components/src/components/pages/auth/login-page.component.ts
+++ b/packages/melodic-components/src/components/pages/auth/login-page.component.ts
@@ -40,24 +40,24 @@ import { loginPageStyles } from './login-page.styles.js';
 	attributes: ['variant', 'title', 'description']
 })
 export class LoginPageComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Layout variant */
-	variant: 'centered' | 'split' = 'centered';
+	public variant: 'centered' | 'split' = 'centered';
 
 	/** Page title */
-	title = 'Log in to your account';
+	public title = 'Log in to your account';
 
 	/** Page description */
-	description = 'Welcome back! Please enter your details.';
+	public description = 'Welcome back! Please enter your details.';
 
 	/** Check if header slot has content */
-	get hasHeaderSlot(): boolean {
+	public get hasHeaderSlot(): boolean {
 		return this.elementRef?.querySelector('[slot="header"]') !== null;
 	}
 
 	/** Check if brand slot has content */
-	get hasBrandSlot(): boolean {
+	public get hasBrandSlot(): boolean {
 		return this.elementRef?.querySelector('[slot="brand"]') !== null;
 	}
 }

--- a/packages/melodic-components/src/components/pages/auth/signup-page.component.ts
+++ b/packages/melodic-components/src/components/pages/auth/signup-page.component.ts
@@ -39,24 +39,24 @@ import { signupPageStyles } from './signup-page.styles.js';
 	attributes: ['variant', 'title', 'description']
 })
 export class SignupPageComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Layout variant */
-	variant: 'centered' | 'split' = 'centered';
+	public variant: 'centered' | 'split' = 'centered';
 
 	/** Page title */
-	title = 'Create an account';
+	public title = 'Create an account';
 
 	/** Page description */
-	description = 'Start your journey today.';
+	public description = 'Start your journey today.';
 
 	/** Check if header slot has content */
-	get hasHeaderSlot(): boolean {
+	public get hasHeaderSlot(): boolean {
 		return this.elementRef?.querySelector('[slot="header"]') !== null;
 	}
 
 	/** Check if brand slot has content */
-	get hasBrandSlot(): boolean {
+	public get hasBrandSlot(): boolean {
 		return this.elementRef?.querySelector('[slot="brand"]') !== null;
 	}
 }

--- a/packages/melodic-components/src/components/pages/dashboard/dashboard-page.component.ts
+++ b/packages/melodic-components/src/components/pages/dashboard/dashboard-page.component.ts
@@ -36,29 +36,29 @@ export type DashboardLayout = 'default' | 'wide' | 'full';
 	attributes: ['title', 'description', 'layout']
 })
 export class DashboardPageComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Page title */
-	title = '';
+	public title = '';
 
 	/** Page description */
-	description = '';
+	public description = '';
 
 	/** Content layout variant */
-	layout: DashboardLayout = 'default';
+	public layout: DashboardLayout = 'default';
 
 	/** Check if metrics slot has content */
-	get hasMetrics(): boolean {
+	public get hasMetrics(): boolean {
 		return this.elementRef?.querySelector('[slot="metrics"]') !== null;
 	}
 
 	/** Check if aside slot has content */
-	get hasAside(): boolean {
+	public get hasAside(): boolean {
 		return this.elementRef?.querySelector('[slot="aside"]') !== null;
 	}
 
 	/** Check if header-actions slot has content */
-	get hasHeaderActions(): boolean {
+	public get hasHeaderActions(): boolean {
 		return this.elementRef?.querySelector('[slot="header-actions"]') !== null;
 	}
 }

--- a/packages/melodic-components/src/components/sections/app-shell/app-shell.component.ts
+++ b/packages/melodic-components/src/components/sections/app-shell/app-shell.component.ts
@@ -30,44 +30,44 @@ export type SidebarPosition = 'left' | 'right';
 	attributes: ['sidebar-position', 'sidebar-collapsed', 'header-fixed']
 })
 export class AppShellComponent implements IElementRef, OnCreate, OnDestroy {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Position of the sidebar: 'left' or 'right' */
-	'sidebar-position': SidebarPosition = 'left';
+	public 'sidebar-position': SidebarPosition = 'left';
 
 	/** Whether the sidebar is collapsed */
-	'sidebar-collapsed' = false;
+	public 'sidebar-collapsed' = false;
 
 	/** Whether the header is fixed/sticky */
-	'header-fixed' = false;
+	public 'header-fixed' = false;
 
 	/** Whether the viewport is mobile-sized (<768px) */
-	mobile = false;
+	public mobile = false;
 
 	/** Whether the mobile sidebar drawer is open */
-	mobileOpen = false;
+	public mobileOpen = false;
 
 	/** Media query for responsive behavior */
 	private _mediaQuery: MediaQueryList | null = null;
 	private readonly _handleMediaChange = this.onMediaChange.bind(this);
 
-	onCreate(): void {
+	public onCreate(): void {
 		this._mediaQuery = window.matchMedia('(min-width: 768px)');
 		this._mediaQuery.addEventListener('change', this._handleMediaChange);
 		this.mobile = !this._mediaQuery.matches;
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this._mediaQuery?.removeEventListener('change', this._handleMediaChange);
 	}
 
 	/** Toggle mobile sidebar drawer */
-	toggleMobileSidebar = (): void => {
+	public toggleMobileSidebar = (): void => {
 		this.mobileOpen = !this.mobileOpen;
 	};
 
 	/** Close mobile sidebar */
-	closeMobileSidebar = (): void => {
+	public closeMobileSidebar = (): void => {
 		this.mobileOpen = false;
 	};
 

--- a/packages/melodic-components/src/components/sections/hero/hero-section.component.ts
+++ b/packages/melodic-components/src/components/sections/hero/hero-section.component.ts
@@ -36,20 +36,20 @@ export type HeroBackground = 'none' | 'subtle' | 'gradient';
 	attributes: ['variant', 'size', 'background', 'title', 'description']
 })
 export class HeroSectionComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Layout variant */
-	variant: HeroVariant = 'centered';
+	public variant: HeroVariant = 'centered';
 
 	/** Size controls padding and font sizes */
-	size: HeroSize = 'lg';
+	public size: HeroSize = 'lg';
 
 	/** Background style */
-	background: HeroBackground = 'none';
+	public background: HeroBackground = 'none';
 
 	/** Headline text (alternative to title slot) */
-	title = '';
+	public title = '';
 
 	/** Supporting text (alternative to description slot) */
-	description = '';
+	public description = '';
 }

--- a/packages/melodic-components/src/components/sections/page-header/page-header.component.ts
+++ b/packages/melodic-components/src/components/sections/page-header/page-header.component.ts
@@ -33,47 +33,47 @@ export type PageHeaderVariant = 'default' | 'compact' | 'centered';
 	attributes: ['variant', 'divider', 'title', 'description']
 })
 export class PageHeaderComponent implements IElementRef {
-	elementRef!: HTMLElement;
+	public elementRef!: HTMLElement;
 
 	/** Page title text */
-	title = '';
+	public title = '';
 
 	/** Page description text */
-	description = '';
+	public description = '';
 
 	/** Visual variant */
-	variant: PageHeaderVariant = 'default';
+	public variant: PageHeaderVariant = 'default';
 
 	/** Show bottom border */
-	divider = true;
+	public divider = true;
 
 	/** Check if breadcrumb slot has content */
-	get hasBreadcrumb(): boolean {
+	public get hasBreadcrumb(): boolean {
 		return this.elementRef?.querySelector('[slot="breadcrumb"]') !== null;
 	}
 
 	/** Check if title slot has content */
-	get hasTitleSlot(): boolean {
+	public get hasTitleSlot(): boolean {
 		return this.elementRef?.querySelector('[slot="title"]') !== null;
 	}
 
 	/** Check if description slot has content */
-	get hasDescriptionSlot(): boolean {
+	public get hasDescriptionSlot(): boolean {
 		return this.elementRef?.querySelector('[slot="description"]') !== null;
 	}
 
 	/** Check if actions slot has content */
-	get hasActions(): boolean {
+	public get hasActions(): boolean {
 		return this.elementRef?.querySelector('[slot="actions"]') !== null;
 	}
 
 	/** Check if tabs slot has content */
-	get hasTabs(): boolean {
+	public get hasTabs(): boolean {
 		return this.elementRef?.querySelector('[slot="tabs"]') !== null;
 	}
 
 	/** Check if meta slot has content */
-	get hasMeta(): boolean {
+	public get hasMeta(): boolean {
 		return this.elementRef?.querySelector('[slot="meta"]') !== null;
 	}
 }

--- a/packages/melodic-components/src/utils/virtual-scroll/index.ts
+++ b/packages/melodic-components/src/utils/virtual-scroll/index.ts
@@ -17,7 +17,7 @@ export class VirtualScroller {
 	private _options: VirtualScrollOptions | null = null;
 
 	/** Attach to a scrollable viewport element and begin observing */
-	attach(viewport: HTMLElement, options: VirtualScrollOptions): void {
+	public attach(viewport: HTMLElement, options: VirtualScrollOptions): void {
 		this._viewport = viewport;
 		this._options = options;
 
@@ -31,7 +31,7 @@ export class VirtualScroller {
 	}
 
 	/** Tear down observers and event listeners */
-	detach(): void {
+	public detach(): void {
 		this._resizeObserver?.disconnect();
 		this._resizeObserver = null;
 		if (this._viewport) {
@@ -42,7 +42,7 @@ export class VirtualScroller {
 	}
 
 	/** Call after item count or row height changes (e.g. after sort/filter/page change) */
-	invalidate(): void {
+	public invalidate(): void {
 		if (!this._viewport) return;
 		this._compute(this._viewport.clientHeight);
 	}

--- a/src/components/classes/component-base.class.ts
+++ b/src/components/classes/component-base.class.ts
@@ -33,11 +33,11 @@ export abstract class ComponentBase extends HTMLElement {
 		}
 	}
 
-	get component(): Component {
+	public get component(): Component {
 		return this._component;
 	}
 
-	async connectedCallback(): Promise<void> {
+	public async connectedCallback(): Promise<void> {
 		this.render();
 
 		if (this._component.onCreate !== undefined) {
@@ -45,7 +45,7 @@ export abstract class ComponentBase extends HTMLElement {
 		}
 	}
 
-	disconnectedCallback(): void {
+	public disconnectedCallback(): void {
 		this._unsubscribers.forEach((unsubscribe) => unsubscribe());
 		this._unsubscribers = [];
 
@@ -69,7 +69,7 @@ export abstract class ComponentBase extends HTMLElement {
 		}
 	}
 
-	attributeChangedCallback(attribute: string, oldVal: unknown, newVal: unknown): void {
+	public attributeChangedCallback(attribute: string, oldVal: unknown, newVal: unknown): void {
 		const prop = attribute.replace(/-([a-z])/g, (_, ch: string) => ch.toUpperCase());
 
 		if ((this._component as any)[prop] !== undefined) {

--- a/src/components/decorators/melodic-component.decorator.ts
+++ b/src/components/decorators/melodic-component.decorator.ts
@@ -26,7 +26,7 @@ export function MelodicComponent<C extends Component>(meta: TypedComponentMeta<C
 					super(meta, Reflect.construct(component, dependencies));
 				}
 
-				static readonly observedAttributes: string[] = meta.attributes ?? [];
+				public static readonly observedAttributes: string[] = meta.attributes ?? [];
 			};
 
 			const componentWithSelector: INewable<C> & { selector?: string } = component as INewable<C> & { selector?: string };

--- a/src/forms/classes/form-control.class.ts
+++ b/src/forms/classes/form-control.class.ts
@@ -6,12 +6,12 @@ import type { ValidatorFn, AsyncValidatorFn, ValidationErrors, ValidationError }
 export const FORM_CONTROL_MARKER = Symbol('melodic.formControl');
 
 export class FormControl<T = unknown> implements IFormControl<T> {
-	readonly [FORM_CONTROL_MARKER] = true;
+	public readonly [FORM_CONTROL_MARKER] = true;
 
-	readonly value: Signal<T>;
-	readonly initialValue: T;
-	readonly errors: Signal<ValidationErrors | null>;
-	readonly updateOn: 'input' | 'blur' | 'submit';
+	public readonly value: Signal<T>;
+	public readonly initialValue: T;
+	public readonly errors: Signal<ValidationErrors | null>;
+	public readonly updateOn: 'input' | 'blur' | 'submit';
 
 	private _validators: ValidatorFn<T>[] = [];
 	private _asyncValidators: AsyncValidatorFn<T>[] = [];
@@ -21,14 +21,14 @@ export class FormControl<T = unknown> implements IFormControl<T> {
 	private readonly _disabled = signal<boolean>(false);
 	private _asyncValidationId = 0;
 
-	readonly dirty: Signal<boolean>;
-	readonly touched: Signal<boolean>;
-	readonly pristine: Signal<boolean>;
-	readonly valid: Signal<boolean>;
-	readonly invalid: Signal<boolean>;
-	readonly pending: Signal<boolean>;
-	readonly disabled: Signal<boolean>;
-	readonly state: Signal<FormControlState>;
+	public readonly dirty: Signal<boolean>;
+	public readonly touched: Signal<boolean>;
+	public readonly pristine: Signal<boolean>;
+	public readonly valid: Signal<boolean>;
+	public readonly invalid: Signal<boolean>;
+	public readonly pending: Signal<boolean>;
+	public readonly disabled: Signal<boolean>;
+	public readonly state: Signal<FormControlState>;
 
 	constructor(initialValue: T, options: FormControlOptions<T> = {}) {
 		this.initialValue = initialValue;
@@ -66,7 +66,7 @@ export class FormControl<T = unknown> implements IFormControl<T> {
 		this.runValidation();
 	}
 
-	setValue(value: T): void {
+	public setValue(value: T): void {
 		if (this._disabled()) return;
 
 		this.value.set(value);
@@ -77,7 +77,7 @@ export class FormControl<T = unknown> implements IFormControl<T> {
 		}
 	}
 
-	patchValue(value: Partial<T>): void {
+	public patchValue(value: Partial<T>): void {
 		if (typeof this.value() === 'object' && this.value() !== null) {
 			this.setValue({ ...this.value(), ...value });
 		} else {
@@ -85,7 +85,7 @@ export class FormControl<T = unknown> implements IFormControl<T> {
 		}
 	}
 
-	reset(value?: T): void {
+	public reset(value?: T): void {
 		this.value.set(value ?? this.initialValue);
 		this._dirty.set(false);
 		this._touched.set(false);
@@ -93,7 +93,7 @@ export class FormControl<T = unknown> implements IFormControl<T> {
 		this.runValidation();
 	}
 
-	markAsTouched(): void {
+	public markAsTouched(): void {
 		this._touched.set(true);
 
 		if (this.updateOn === 'blur') {
@@ -101,59 +101,59 @@ export class FormControl<T = unknown> implements IFormControl<T> {
 		}
 	}
 
-	markAsUntouched(): void {
+	public markAsUntouched(): void {
 		this._touched.set(false);
 	}
 
-	markAsDirty(): void {
+	public markAsDirty(): void {
 		this._dirty.set(true);
 	}
 
-	markAsPristine(): void {
+	public markAsPristine(): void {
 		this._dirty.set(false);
 	}
 
-	disable(): void {
+	public disable(): void {
 		this._disabled.set(true);
 	}
 
-	enable(): void {
+	public enable(): void {
 		this._disabled.set(false);
 	}
 
-	setValidators(validators: ValidatorFn<T>[]): void {
+	public setValidators(validators: ValidatorFn<T>[]): void {
 		this._validators = validators;
 		this.runValidation();
 	}
 
-	setAsyncValidators(validators: AsyncValidatorFn<T>[]): void {
+	public setAsyncValidators(validators: AsyncValidatorFn<T>[]): void {
 		this._asyncValidators = validators;
 		this.runValidation();
 	}
 
-	addValidators(validators: ValidatorFn<T>[]): void {
+	public addValidators(validators: ValidatorFn<T>[]): void {
 		this._validators = [...this._validators, ...validators];
 		this.runValidation();
 	}
 
-	removeValidators(validators: ValidatorFn<T>[]): void {
+	public removeValidators(validators: ValidatorFn<T>[]): void {
 		this._validators = this._validators.filter((v) => !validators.includes(v));
 		this.runValidation();
 	}
 
-	async validate(): Promise<void> {
+	public async validate(): Promise<void> {
 		await this.runValidation();
 	}
 
-	getError(code: string): ValidationError | null {
+	public getError(code: string): ValidationError | null {
 		return this.errors()?.[code] ?? null;
 	}
 
-	hasError(code: string): boolean {
+	public hasError(code: string): boolean {
 		return this.errors()?.[code] !== undefined;
 	}
 
-	destroy(): void {
+	public destroy(): void {
 		this.value.destroy();
 		this.errors.destroy();
 		this._touched.destroy();

--- a/src/forms/classes/form-group.class.ts
+++ b/src/forms/classes/form-group.class.ts
@@ -7,24 +7,24 @@ import type { ValidatorFn, AsyncValidatorFn, ValidationErrors, ValidationError }
 export const FORM_GROUP_MARKER = Symbol('melodic.formGroup');
 
 export class FormGroup<T extends Record<string, unknown> = Record<string, unknown>> implements IFormGroup<T> {
-	readonly [FORM_GROUP_MARKER] = true;
+	public readonly [FORM_GROUP_MARKER] = true;
 
-	readonly controls: FormGroupControls<T>;
-	readonly value: Signal<FormGroupValue<T>>;
-	readonly errors: Signal<ValidationErrors | null>;
+	public readonly controls: FormGroupControls<T>;
+	public readonly value: Signal<FormGroupValue<T>>;
+	public readonly errors: Signal<ValidationErrors | null>;
 
 	private _validators: ValidatorFn<FormGroupValue<T>>[] = [];
 	private readonly _asyncValidators: AsyncValidatorFn<FormGroupValue<T>>[] = [];
 	private readonly _disabled = signal<boolean>(false);
 	private readonly _controlEffects: SignalEffect[] = [];
 
-	readonly valid: Signal<boolean>;
-	readonly invalid: Signal<boolean>;
-	readonly pending: Signal<boolean>;
-	readonly dirty: Signal<boolean>;
-	readonly touched: Signal<boolean>;
-	readonly pristine: Signal<boolean>;
-	readonly disabled: Signal<boolean>;
+	public readonly valid: Signal<boolean>;
+	public readonly invalid: Signal<boolean>;
+	public readonly pending: Signal<boolean>;
+	public readonly dirty: Signal<boolean>;
+	public readonly touched: Signal<boolean>;
+	public readonly pristine: Signal<boolean>;
+	public readonly disabled: Signal<boolean>;
 
 	constructor(controls: FormGroupControls<T>, options: FormGroupOptions<T> = {}) {
 		this.controls = controls;
@@ -68,24 +68,24 @@ export class FormGroup<T extends Record<string, unknown> = Record<string, unknow
 		this.runGroupValidation();
 	}
 
-	get<K extends keyof T>(name: K): IFormControl<T[K]> {
+	public get<K extends keyof T>(name: K): IFormControl<T[K]> {
 		return this.controls[name];
 	}
 
-	addControl<K extends string, V>(name: K, control: IFormControl<V>): void {
+	public addControl<K extends string, V>(name: K, control: IFormControl<V>): void {
 		(this.controls as Record<string, IFormControl<unknown>>)[name] = control;
 		this.setupControlWatcher(control);
 	}
 
-	removeControl<K extends keyof T>(name: K): void {
+	public removeControl<K extends keyof T>(name: K): void {
 		delete (this.controls as Record<string, IFormControl<unknown>>)[name as string];
 	}
 
-	contains<K extends keyof T>(name: K): boolean {
+	public contains<K extends keyof T>(name: K): boolean {
 		return name in this.controls;
 	}
 
-	setValue(value: FormGroupValue<T>): void {
+	public setValue(value: FormGroupValue<T>): void {
 		Object.keys(value).forEach((key) => {
 			const control = this.controls[key as keyof T];
 			if (control) {
@@ -94,7 +94,7 @@ export class FormGroup<T extends Record<string, unknown> = Record<string, unknow
 		});
 	}
 
-	patchValue(value: Partial<FormGroupValue<T>>): void {
+	public patchValue(value: Partial<FormGroupValue<T>>): void {
 		Object.keys(value).forEach((key) => {
 			const control = this.controls[key as keyof T];
 			if (control && value[key as keyof T] !== undefined) {
@@ -103,7 +103,7 @@ export class FormGroup<T extends Record<string, unknown> = Record<string, unknow
 		});
 	}
 
-	reset(value?: Partial<FormGroupValue<T>>): void {
+	public reset(value?: Partial<FormGroupValue<T>>): void {
 		Object.keys(this.controls).forEach((key) => {
 			const control = this.controls[key as keyof T];
 			const resetValue = value?.[key as keyof T];
@@ -111,63 +111,63 @@ export class FormGroup<T extends Record<string, unknown> = Record<string, unknow
 		});
 	}
 
-	markAllAsTouched(): void {
+	public markAllAsTouched(): void {
 		Object.values(this.controls).forEach((control) => {
 			(control as IFormControl).markAsTouched();
 		});
 	}
 
-	markAllAsUntouched(): void {
+	public markAllAsUntouched(): void {
 		Object.values(this.controls).forEach((control) => {
 			(control as IFormControl).markAsUntouched();
 		});
 	}
 
-	markAllAsDirty(): void {
+	public markAllAsDirty(): void {
 		Object.values(this.controls).forEach((control) => {
 			(control as IFormControl).markAsDirty();
 		});
 	}
 
-	markAllAsPristine(): void {
+	public markAllAsPristine(): void {
 		Object.values(this.controls).forEach((control) => {
 			(control as IFormControl).markAsPristine();
 		});
 	}
 
-	disable(): void {
+	public disable(): void {
 		this._disabled.set(true);
 		Object.values(this.controls).forEach((control) => {
 			(control as IFormControl).disable();
 		});
 	}
 
-	enable(): void {
+	public enable(): void {
 		this._disabled.set(false);
 		Object.values(this.controls).forEach((control) => {
 			(control as IFormControl).enable();
 		});
 	}
 
-	async validate(): Promise<void> {
+	public async validate(): Promise<void> {
 		await Promise.all(Object.values(this.controls).map((control) => (control as IFormControl).validate()));
 		await this.runGroupValidation();
 	}
 
-	setValidators(validators: ValidatorFn<FormGroupValue<T>>[]): void {
+	public setValidators(validators: ValidatorFn<FormGroupValue<T>>[]): void {
 		this._validators = validators;
 		this.runGroupValidation();
 	}
 
-	getError(code: string): ValidationError | null {
+	public getError(code: string): ValidationError | null {
 		return this.errors()?.[code] ?? null;
 	}
 
-	hasError(code: string): boolean {
+	public hasError(code: string): boolean {
 		return this.errors()?.[code] !== undefined;
 	}
 
-	destroy(): void {
+	public destroy(): void {
 		this._controlEffects.forEach((effect) => effect.destroy());
 		Object.values(this.controls).forEach((control) => {
 			(control as IFormControl).destroy();

--- a/src/http/classes/request-manager.class.ts
+++ b/src/http/classes/request-manager.class.ts
@@ -10,7 +10,7 @@ interface IPendingRequest<T = any> {
 export class RequestManager {
 	private _pendingRequests = new Map<string, IPendingRequest>();
 
-	generateRequestKey(method: string, url: string, body?: HttpRequestBody): string {
+	public generateRequestKey(method: string, url: string, body?: HttpRequestBody): string {
 		let key = `${method}:${url}`;
 
 		if (body) {
@@ -20,11 +20,11 @@ export class RequestManager {
 		return key;
 	}
 
-	hasPendingRequest(key: string): boolean {
+	public hasPendingRequest(key: string): boolean {
 		return this._pendingRequests.has(key);
 	}
 
-	getPendingRequest<T = any>(key: string): Promise<IHttpResponse<T>> | null {
+	public getPendingRequest<T = any>(key: string): Promise<IHttpResponse<T>> | null {
 		const pending = this._pendingRequests.get(key);
 
 		if (!pending) {
@@ -34,7 +34,7 @@ export class RequestManager {
 		return pending.promise;
 	}
 
-	addPendingRequest<T = any>(requestConfig: IRequestConfig, promise: Promise<IHttpResponse<T>>): void {
+	public addPendingRequest<T = any>(requestConfig: IRequestConfig, promise: Promise<IHttpResponse<T>>): void {
 		const key = this.generateRequestKey(requestConfig.method || 'GET', requestConfig.url || '', requestConfig.body as BodyInit | null);
 
 		this._pendingRequests.set(key, {
@@ -47,7 +47,7 @@ export class RequestManager {
 		});
 	}
 
-	cancelPendingRequest(key: string, reason?: string): void {
+	public cancelPendingRequest(key: string, reason?: string): void {
 		const pending = this._pendingRequests.get(key);
 
 		if (pending) {
@@ -56,7 +56,7 @@ export class RequestManager {
 		}
 	}
 
-	cancelAllRequests(reason?: string): void {
+	public cancelAllRequests(reason?: string): void {
 		this._pendingRequests.forEach((pending) => {
 			pending.abortController.abort(reason);
 		});

--- a/src/injection/classes/binding.class.ts
+++ b/src/injection/classes/binding.class.ts
@@ -4,9 +4,9 @@ import type { Token } from '../types/token.type';
 import { getTokenKey } from '../function/get-token-key.function';
 
 export class Binding<T> {
-	readonly key: string;
-	readonly token: Token<T>;
-	readonly type: BindingType;
+	public readonly key: string;
+	public readonly token: Token<T>;
+	public readonly type: BindingType;
 
 	private _class?: INewable<T>;
 	private _factory?: () => T;
@@ -22,66 +22,66 @@ export class Binding<T> {
 		this.type = type;
 	}
 
-	get isSingleton(): boolean {
+	public get isSingleton(): boolean {
 		return this._singleton;
 	}
 
-	get isResolved(): boolean {
+	public get isResolved(): boolean {
 		return this._resolved;
 	}
 
-	get dependencies(): string[] {
+	public get dependencies(): string[] {
 		return this._dependencies;
 	}
 
-	get args(): unknown[] {
+	public get args(): unknown[] {
 		return this._args;
 	}
 
-	get targetClass(): INewable<T> | undefined {
+	public get targetClass(): INewable<T> | undefined {
 		return this._class;
 	}
 
-	get factory(): (() => T) | undefined {
+	public get factory(): (() => T) | undefined {
 		return this._factory;
 	}
 
-	setClass(cls: INewable<T>): this {
+	public setClass(cls: INewable<T>): this {
 		this._class = cls;
 		return this;
 	}
 
-	setFactory(factory: () => T): this {
+	public setFactory(factory: () => T): this {
 		this._factory = factory;
 		return this;
 	}
 
-	setSingleton(value: boolean): this {
+	public setSingleton(value: boolean): this {
 		this._singleton = value;
 		return this;
 	}
 
-	withDependencies(deps: Token<unknown>[]): this {
+	public withDependencies(deps: Token<unknown>[]): this {
 		this._dependencies = deps.map((dep) => getTokenKey(dep));
 		return this;
 	}
 
-	withArgs(args: unknown[]): this {
+	public withArgs(args: unknown[]): this {
 		this._args = args;
 		return this;
 	}
 
-	getInstance(): T | undefined {
+	public getInstance(): T | undefined {
 		return this._instance;
 	}
 
-	setInstance(instance: T): this {
+	public setInstance(instance: T): this {
 		this._instance = instance;
 		this._resolved = true;
 		return this;
 	}
 
-	clearInstance(): this {
+	public clearInstance(): this {
 		this._instance = undefined;
 		this._resolved = false;
 		return this;

--- a/src/injection/classes/injection-engine.class.ts
+++ b/src/injection/classes/injection-engine.class.ts
@@ -16,9 +16,9 @@ export class InjectionEngine {
 	 * @overload bind(token, cls) - Use custom token with class
 	 * @overload bind(token, cls, options) - Use custom token with class and options
 	 */
-	bind<T>(cls: INewable<T>, options?: IClassBindingOptions): Binding<T>;
-	bind<T>(token: Token<T>, cls: INewable<T>, options?: IClassBindingOptions): Binding<T>;
-	bind<T>(tokenOrClass: Token<T> | INewable<T>, clsOrOptions?: INewable<T> | IClassBindingOptions, maybeOptions?: IClassBindingOptions): Binding<T> {
+	public bind<T>(cls: INewable<T>, options?: IClassBindingOptions): Binding<T>;
+	public bind<T>(token: Token<T>, cls: INewable<T>, options?: IClassBindingOptions): Binding<T>;
+	public bind<T>(tokenOrClass: Token<T> | INewable<T>, clsOrOptions?: INewable<T> | IClassBindingOptions, maybeOptions?: IClassBindingOptions): Binding<T> {
 		let token: Token<T>;
 		let cls: INewable<T>;
 		let options: IClassBindingOptions | undefined;
@@ -53,9 +53,9 @@ export class InjectionEngine {
 		return binding;
 	}
 
-	bindValue<T>(token: Token<T>, value: T): Binding<T>;
-	bindValue<T, V>(token: Token<T>, value: V): Binding<T>;
-	bindValue<T>(token: Token<T>, value: unknown): Binding<T> {
+	public bindValue<T>(token: Token<T>, value: T): Binding<T>;
+	public bindValue<T, V>(token: Token<T>, value: V): Binding<T>;
+	public bindValue<T>(token: Token<T>, value: unknown): Binding<T> {
 		const key = getTokenKey(token);
 		const binding = new Binding<T>(key, token, 'value');
 
@@ -67,7 +67,7 @@ export class InjectionEngine {
 		return binding;
 	}
 
-	bindFactory<T>(token: Token<T>, factory: () => T, options?: IFactoryBindingOptions): Binding<T> {
+	public bindFactory<T>(token: Token<T>, factory: () => T, options?: IFactoryBindingOptions): Binding<T> {
 		const key = getTokenKey(token);
 		const binding = new Binding<T>(key, token, 'factory');
 		binding.setFactory(factory);
@@ -81,7 +81,7 @@ export class InjectionEngine {
 		return binding;
 	}
 
-	get<T>(token: Token<T>): T {
+	public get<T>(token: Token<T>): T {
 		const key = getTokenKey(token);
 		const binding = this._bindings.get(key) as Binding<T> | undefined;
 
@@ -92,22 +92,22 @@ export class InjectionEngine {
 		return this.resolve(binding, key);
 	}
 
-	has<T>(token: Token<T>): boolean {
+	public has<T>(token: Token<T>): boolean {
 		const key = getTokenKey(token);
 		return this._bindings.has(key);
 	}
 
-	getBinding<T>(token: Token<T>): Binding<T> | undefined {
+	public getBinding<T>(token: Token<T>): Binding<T> | undefined {
 		const key = getTokenKey(token);
 		return this._bindings.get(key) as Binding<T> | undefined;
 	}
 
-	unbind<T>(token: Token<T>): boolean {
+	public unbind<T>(token: Token<T>): boolean {
 		const key = getTokenKey(token);
 		return this._bindings.delete(key);
 	}
 
-	clear(): void {
+	public clear(): void {
 		this._bindings.clear();
 	}
 

--- a/src/routing/classes/route-matcher.class.ts
+++ b/src/routing/classes/route-matcher.class.ts
@@ -28,7 +28,7 @@ export class RouteMatcher {
 		this._prefixRegex = new RegExp('^' + escapedRoute + '(?:/|$)');
 	}
 
-	parse(url: string): RouteMatchParams {
+	public parse(url: string): RouteMatchParams {
 		let i: number = 0;
 		let param: Rule;
 		let value: string;
@@ -53,7 +53,7 @@ export class RouteMatcher {
 		return params;
 	}
 
-	parsePrefix(url: string): { params: RouteMatchParams; matchedPath: string; remainingPath: string } | null {
+	public parsePrefix(url: string): { params: RouteMatchParams; matchedPath: string; remainingPath: string } | null {
 		if (this._route === '') {
 			return {
 				params: {},
@@ -85,7 +85,7 @@ export class RouteMatcher {
 		return { params, matchedPath, remainingPath };
 	}
 
-	stringify(params: Record<string, string>): string {
+	public stringify(params: Record<string, string>): string {
 		let re: RegExp;
 		let result: string = this._route;
 

--- a/src/routing/components/router-link/router-link.component.ts
+++ b/src/routing/components/router-link/router-link.component.ts
@@ -35,7 +35,7 @@ export class RouterLinkComponent {
 	public replace: boolean = false;
 	public elementRef!: HTMLElement;
 
-	onCreate(): void {
+	public onCreate(): void {
 		this._anchorElement = this.elementRef.shadowRoot?.querySelector('a') ?? null;
 
 		const initialHref = this.elementRef.getAttribute('href');
@@ -73,11 +73,11 @@ export class RouterLinkComponent {
 		this.updateActiveState();
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this._navigationCleanup?.();
 	}
 
-	onAttributeChange(attribute: string, _: unknown, newVal: unknown): void {
+	public onAttributeChange(attribute: string, _: unknown, newVal: unknown): void {
 		if (attribute === 'href') {
 			this.href = newVal as string;
 			this.updateAnchorHref();
@@ -88,14 +88,14 @@ export class RouterLinkComponent {
 		}
 	}
 
-	onPropertyChange(name: string): void {
+	public onPropertyChange(name: string): void {
 		if (name === 'href' || name === 'queryParams') {
 			this.updateAnchorHref();
 			this.updateActiveState();
 		}
 	}
 
-	isActive(): boolean {
+	public isActive(): boolean {
 		const currentPath = window.location.pathname;
 		const linkPath = this.href.startsWith('/') ? this.href : `/${this.href}`;
 

--- a/src/routing/components/router-outlet/router-outlet.component.ts
+++ b/src/routing/components/router-outlet/router-outlet.component.ts
@@ -41,7 +41,7 @@ export class RouterOutletComponent {
 	public name: string = 'primary';
 	public elementRef!: HTMLElement;
 
-	onInit(): void {
+	public onInit(): void {
 		const handler = () => this.onNavigate();
 		window.addEventListener('NavigationEvent', handler);
 		this._navigationCleanup = () => window.removeEventListener('NavigationEvent', handler);
@@ -56,7 +56,7 @@ export class RouterOutletComponent {
 		}) as EventListener);
 	}
 
-	onCreate(): void {
+	public onCreate(): void {
 		this.findParentOutlet();
 
 		// Defer initial render to allow property binding to complete
@@ -78,7 +78,7 @@ export class RouterOutletComponent {
 		});
 	}
 
-	onDestroy(): void {
+	public onDestroy(): void {
 		this._navigationCleanup?.();
 
 		if (this._parentOutlet) {
@@ -86,7 +86,7 @@ export class RouterOutletComponent {
 		}
 	}
 
-	onPropertyChange(name: string): void {
+	public onPropertyChange(name: string): void {
 		if (name === 'routes' && this._initialized) {
 			// Routes changed - update router if root and re-render
 			if (this._depth === 0) {
@@ -97,11 +97,11 @@ export class RouterOutletComponent {
 		}
 	}
 
-	getDepth(): number {
+	public getDepth(): number {
 		return this._depth;
 	}
 
-	getContext(): IRouteContext | null {
+	public getContext(): IRouteContext | null {
 		return this._context;
 	}
 

--- a/src/routing/services/route-context.service.ts
+++ b/src/routing/services/route-context.service.ts
@@ -11,7 +11,7 @@ export class RouteContextService {
 	private _currentMatchResult: IRouteMatchResult | null = null;
 	private _resolvedData: Map<number, Record<string, unknown>> = new Map();
 
-	setMatchResult(result: IRouteMatchResult): void {
+	public setMatchResult(result: IRouteMatchResult): void {
 		this._currentMatchResult = result;
 		this._matchStack = result.matches;
 
@@ -42,19 +42,19 @@ export class RouteContextService {
 		}
 	}
 
-	setResolvedData(depth: number, data: Record<string, unknown>): void {
+	public setResolvedData(depth: number, data: Record<string, unknown>): void {
 		this._resolvedData.set(depth, data);
 	}
 
-	clearResolvedData(): void {
+	public clearResolvedData(): void {
 		this._resolvedData.clear();
 	}
 
-	getContextForDepth(depth: number): IRouteContext | undefined {
+	public getContextForDepth(depth: number): IRouteContext | undefined {
 		return this._contexts.get(depth);
 	}
 
-	getChildRoutesForDepth(depth: number): IRoute[] {
+	public getChildRoutesForDepth(depth: number): IRoute[] {
 		const parentContext = this._contexts.get(depth - 1);
 
 		if (depth === 0) {
@@ -64,7 +64,7 @@ export class RouteContextService {
 		return parentContext?.currentMatch?.children ?? [];
 	}
 
-	getRemainingPathForDepth(depth: number): string {
+	public getRemainingPathForDepth(depth: number): string {
 		if (depth === 0) {
 			return window.location.pathname;
 		}
@@ -74,24 +74,24 @@ export class RouteContextService {
 		return parentContext?.remainingPath ?? '';
 	}
 
-	getParamsForDepth(depth: number): Record<string, string> {
+	public getParamsForDepth(depth: number): Record<string, string> {
 		const context = this._contexts.get(depth);
 		return context?.params ?? {};
 	}
 
-	getCurrentParams(): Record<string, string> {
+	public getCurrentParams(): Record<string, string> {
 		return this._currentMatchResult?.params ?? {};
 	}
 
-	getMatchStack(): IRouteMatch[] {
+	public getMatchStack(): IRouteMatch[] {
 		return [...this._matchStack];
 	}
 
-	getCurrentMatchResult(): IRouteMatchResult | null {
+	public getCurrentMatchResult(): IRouteMatchResult | null {
 		return this._currentMatchResult;
 	}
 
-	getMergedRouteData(depth?: number): Record<string, unknown> {
+	public getMergedRouteData(depth?: number): Record<string, unknown> {
 		const maxDepth = depth ?? this._matchStack.length - 1;
 		const merged: Record<string, unknown> = {};
 
@@ -105,7 +105,7 @@ export class RouteContextService {
 		return merged;
 	}
 
-	getMergedResolvedData(depth?: number): Record<string, unknown> {
+	public getMergedResolvedData(depth?: number): Record<string, unknown> {
 		const maxDepth = depth ?? this._matchStack.length - 1;
 		const merged: Record<string, unknown> = {};
 
@@ -119,7 +119,7 @@ export class RouteContextService {
 		return merged;
 	}
 
-	getResolvedDataForDepth(depth: number): Record<string, unknown> | undefined {
+	public getResolvedDataForDepth(depth: number): Record<string, unknown> | undefined {
 		return this._resolvedData.get(depth);
 	}
 }

--- a/src/routing/services/router.service.ts
+++ b/src/routing/services/router.service.ts
@@ -75,56 +75,56 @@ export class RouterService {
 		});
 	}
 
-	setRoutes(routes: IRoute[]): void {
+	public setRoutes(routes: IRoute[]): void {
 		this._routes = routes;
 	}
 
-	getRoutes(): IRoute[] {
+	public getRoutes(): IRoute[] {
 		return this._routes;
 	}
 
-	getContextService(): RouteContextService {
+	public getContextService(): RouteContextService {
 		return this._contextService;
 	}
 
-	getRoute(): IRouterEventState | undefined {
+	public getRoute(): IRouterEventState | undefined {
 		return this._route;
 	}
 
-	getParams(): Record<string, string> {
+	public getParams(): Record<string, string> {
 		return this._contextService.getCurrentParams();
 	}
 
-	getParam(name: string): string | undefined {
+	public getParam(name: string): string | undefined {
 		return this._contextService.getCurrentParams()[name];
 	}
 
-	getQueryParams(): URLSearchParams {
+	public getQueryParams(): URLSearchParams {
 		return new URLSearchParams(window.location.search);
 	}
 
-	getCurrentMatches(): IRouteMatch[] {
+	public getCurrentMatches(): IRouteMatch[] {
 		return [...this._currentMatches];
 	}
 
-	getRouteData(depth?: number): Record<string, unknown> {
+	public getRouteData(depth?: number): Record<string, unknown> {
 		return this._contextService.getMergedRouteData(depth);
 	}
 
-	getResolvedData(depth?: number): Record<string, unknown> {
+	public getResolvedData(depth?: number): Record<string, unknown> {
 		return this._contextService.getMergedResolvedData(depth);
 	}
 
-	matchPath(path: string): IRouteMatchResult {
+	public matchPath(path: string): IRouteMatchResult {
 		return matchRouteTree(this._routes, path);
 	}
 
-	setCurrentMatches(result: IRouteMatchResult): void {
+	public setCurrentMatches(result: IRouteMatchResult): void {
 		this._currentMatches = result.matches;
 		this._contextService.setMatchResult(result);
 	}
 
-	async runResolvers(matchResult: IRouteMatchResult): Promise<{ success: boolean; error?: string }> {
+	public async runResolvers(matchResult: IRouteMatchResult): Promise<{ success: boolean; error?: string }> {
 		const currentPath = `${window.location.pathname}${window.location.search}`;
 
 		if (this._resolversExecutedForPath === currentPath) {
@@ -137,7 +137,7 @@ export class RouterService {
 		return result;
 	}
 
-	async navigate(path: string, options: INavigationOptions = {}): Promise<INavigationResult> {
+	public async navigate(path: string, options: INavigationOptions = {}): Promise<INavigationResult> {
 		const { data, replace = false, queryParams, skipGuards = false, skipResolvers = false, scrollToTop = true } = options;
 
 		let fullPath = path;
@@ -219,7 +219,7 @@ export class RouterService {
 		};
 	}
 
-	async navigateByName(name: string, params: Record<string, string> = {}, options: INavigationOptions = {}): Promise<INavigationResult> {
+	public async navigateByName(name: string, params: Record<string, string> = {}, options: INavigationOptions = {}): Promise<INavigationResult> {
 		const path = buildPathFromRoute(this._routes, name, params);
 
 		if (!path) {
@@ -232,24 +232,24 @@ export class RouterService {
 		return this.navigate(path, options);
 	}
 
-	replace(path: string, data?: unknown): void {
+	public replace(path: string, data?: unknown): void {
 		history.replaceState(data, '', path);
 		this._currentPath = `${window.location.pathname}${window.location.search}`;
 	}
 
-	back(): void {
+	public back(): void {
 		history.back();
 	}
 
-	forward(): void {
+	public forward(): void {
 		history.forward();
 	}
 
-	go(delta: number): void {
+	public go(delta: number): void {
 		history.go(delta);
 	}
 
-	async runDeactivationGuards(targetPath: string): Promise<boolean | string> {
+	public async runDeactivationGuards(targetPath: string): Promise<boolean | string> {
 		for (const match of this._currentMatches) {
 			const guards = match.route.canDeactivate ?? [];
 
@@ -272,7 +272,7 @@ export class RouterService {
 		return true;
 	}
 
-	async runGuards(matchResult: IRouteMatchResult): Promise<boolean | string> {
+	public async runGuards(matchResult: IRouteMatchResult): Promise<boolean | string> {
 		for (const match of matchResult.matches) {
 			const guards = match.route.canActivate ?? [];
 

--- a/src/signals/classes/signal-effect.class.ts
+++ b/src/signals/classes/signal-effect.class.ts
@@ -6,7 +6,7 @@ export class SignalEffect {
 	private _isRunning = false;
 	private _needsRerun = false;
 
-	readonly run: () => void;
+	public readonly run: () => void;
 
 	constructor(public execute: () => void) {
 		this.run = () => {
@@ -38,11 +38,11 @@ export class SignalEffect {
 		};
 	}
 
-	addDependency<T>(signal: Signal<T>): void {
+	public addDependency<T>(signal: Signal<T>): void {
 		this._dependencies.add(signal);
 	}
 
-	destroy(): void {
+	public destroy(): void {
 		this._dependencies.forEach((signal) => {
 			signal.unsubscribe(this.run);
 		});

--- a/src/state/services/component-state-base.service.ts
+++ b/src/state/services/component-state-base.service.ts
@@ -18,15 +18,15 @@ export abstract class ComponentStateBaseService<S extends object> extends Effect
 		return this._state();
 	}
 
-	resetState(): void {
+	public resetState(): void {
 		this._state.set(this._initState);
 	}
 
-	select<T>(selectFn: (state: S) => T): Signal<T> {
+	public select<T>(selectFn: (state: S) => T): Signal<T> {
 		return computed(() => selectFn(this._state()));
 	}
 
-	dispatch<T extends ActionIdentifier, P extends ActionPayload>(action: TypedAction<T, P>): void {
+	public dispatch<T extends ActionIdentifier, P extends ActionPayload>(action: TypedAction<T, P>): void {
 		if (this._debug) {
 			console.log(`[ComponentState] Action: ${action.type}`);
 			console.log(`[ComponentState] Payload:`, action.payload);

--- a/src/state/services/signal-store.service.ts
+++ b/src/state/services/signal-store.service.ts
@@ -20,19 +20,19 @@ export class SignalStoreService<S> {
 		}
 	}
 
-	select<T, K extends keyof S>(key: K, selectFn: (state: S[K]) => T): Signal<T> {
+	public select<T, K extends keyof S>(key: K, selectFn: (state: S[K]) => T): Signal<T> {
 		return computed(() => {
 			return selectFn(this._state[key]());
 		});
 	}
 
-	logState(): void {
+	public logState(): void {
 		console.log(this.getCurrentState());
 	}
 
-	dispatch<T extends ActionIdentifier, P extends ActionPayload>(action: TypedAction<T, P>): void;
-	dispatch<K extends keyof S, T extends ActionIdentifier, P extends ActionPayload>(key: K, action: TypedAction<T, P>): void;
-	dispatch<K extends keyof S, T extends ActionIdentifier, P extends ActionPayload>(x: K | TypedAction<T, P>, y?: TypedAction<T, P>): void {
+	public dispatch<T extends ActionIdentifier, P extends ActionPayload>(action: TypedAction<T, P>): void;
+	public dispatch<K extends keyof S, T extends ActionIdentifier, P extends ActionPayload>(key: K, action: TypedAction<T, P>): void;
+	public dispatch<K extends keyof S, T extends ActionIdentifier, P extends ActionPayload>(x: K | TypedAction<T, P>, y?: TypedAction<T, P>): void {
 		const key = typeof x === 'string' ? x : undefined;
 		const action: TypedAction<T, P> = (typeof x === 'string' ? y : x) as TypedAction<T, P>;
 

--- a/src/template/classes/compiled-template.class.ts
+++ b/src/template/classes/compiled-template.class.ts
@@ -24,7 +24,7 @@ export class CompiledTemplate {
 		this.analyzeAndCompile(strings);
 	}
 
-	static compile(strings: TemplateStringsArray): CompiledTemplate {
+	public static compile(strings: TemplateStringsArray): CompiledTemplate {
 		let compiled = compiledCache.get(strings);
 		if (!compiled) {
 			compiled = new CompiledTemplate(strings);
@@ -36,14 +36,14 @@ export class CompiledTemplate {
 	/**
 	 * Check if this template can use the fast path
 	 */
-	canUseFastPath(): boolean {
+	public canUseFastPath(): boolean {
 		return this._canCompile && !this._hasEvents;
 	}
 
 	/**
 	 * Create DOM nodes using the compiled factory
 	 */
-	create(values: unknown[]): CompiledResult {
+	public create(values: unknown[]): CompiledResult {
 		if (this._factory) {
 			return { nodes: [this._factory(values)], eventTargets: [] };
 		}
@@ -53,7 +53,7 @@ export class CompiledTemplate {
 	/**
 	 * Directly create a single node - faster than create() for single-element templates
 	 */
-	createDirect(values: unknown[]): Node | null {
+	public createDirect(values: unknown[]): Node | null {
 		return this._factory ? this._factory(values) : null;
 	}
 

--- a/src/template/classes/template-result.class.ts
+++ b/src/template/classes/template-result.class.ts
@@ -30,8 +30,8 @@ function getTemplateKey(strings: TemplateStringsArray): string {
 }
 
 export class TemplateResult {
-	strings: TemplateStringsArray;
-	values: unknown[];
+	public strings: TemplateStringsArray;
+	public values: unknown[];
 
 	constructor(strings: TemplateStringsArray, values: unknown[]) {
 		this.strings = strings;
@@ -42,7 +42,7 @@ export class TemplateResult {
 	 * Optimized render for single-use containers (like repeat items).
 	 * Returns the rendered nodes directly.
 	 */
-	renderOnce(container: DocumentFragment): Node[] {
+	public renderOnce(container: DocumentFragment): Node[] {
 		const templateKey = getTemplateKey(this.strings);
 		const cache = this.getTemplate(templateKey);
 		const clone = cache.element.content.cloneNode(true);
@@ -57,7 +57,7 @@ export class TemplateResult {
 		return Array.from(container.childNodes);
 	}
 
-	renderInto(container: Element | DocumentFragment): void {
+	public renderInto(container: Element | DocumentFragment): void {
 		const templateKey = getTemplateKey(this.strings);
 
 		// Get or create template

--- a/src/template/directives/directive.class.ts
+++ b/src/template/directives/directive.class.ts
@@ -1,7 +1,7 @@
 import type { IDirectiveResult } from './interfaces/idirective-result.interface';
 
 export abstract class Directive implements IDirectiveResult {
-	abstract render(container: Node, previousState?: any): any;
+	public abstract render(container: Node, previousState?: any): any;
 
-	__directive = true as const;
+	public __directive = true as const;
 }

--- a/tools/standards/eslint.config.mjs
+++ b/tools/standards/eslint.config.mjs
@@ -56,6 +56,10 @@ export default [
 				{ selector: 'classProperty', modifiers: ['private'], format: ['camelCase'], leadingUnderscore: 'require' },
 				{ selector: 'classProperty', modifiers: ['protected', 'public'], format: ['camelCase'], leadingUnderscore: 'forbid' }
 			],
+			'@typescript-eslint/explicit-member-accessibility': ['error', {
+				accessibility: 'explicit',
+				overrides: { constructors: 'off' }
+			}],
 			'@typescript-eslint/no-explicit-any': 'warn',
 			'@typescript-eslint/no-unused-vars': [
 				'error',


### PR DESCRIPTION
## Summary
- Adds `@typescript-eslint/explicit-member-accessibility` ESLint rule requiring explicit `public`/`private`/`protected` on all class members (constructors excluded)
- Fixes all 1,034 violations across 90 files in both core framework (`src/`) and components library (`packages/melodic-components/`)
- Removes unused `_slottedItems` field from sidebar component that was uncovered during the fix

## Test plan
- [x] All 62 unit tests pass
- [x] Production build succeeds
- [x] ESLint reports 0 `explicit-member-accessibility` violations
- [x] No new TypeScript errors introduced